### PR TITLE
V1.43

### DIFF
--- a/DHCP_Inventory_V1_4_ReadMe.rtf
+++ b/DHCP_Inventory_V1_4_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -92,9 +92,9 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid223821
-\rsid288140\rsid1860407\rsid3830441\rsid4810367\rsid5384286\rsid5588031\rsid5853019\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030\rsid11807305\rsid12196856
-\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768\rsid16463664}{\mmathPr
-\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy15\hr12\min47}{\version27}{\edmins183}
+\rsid288140\rsid1860407\rsid3830441\rsid4810367\rsid5384286\rsid5588031\rsid5853019\rsid6317044\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030\rsid11807305
+\rsid12196856\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768\rsid16463664}
+{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy16\hr6\min36}{\version28}{\edmins184}
 {\nofpages20}{\nofwords5546}{\nofchars31614}{\nofcharsws37086}{\vern125}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -234,12 +234,13 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools fo\hich\af37\dbch\af31505\loch\f37 r Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e440073}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e44007300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -247,8 +248,8 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
-\hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f0034}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
+\hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for \hich\af43\dbch\af31505\loch\f43 Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 4.\tab}\hich\af37\dbch\af31505\loch\f37 The DHCPServer module is required.
@@ -260,16 +261,16 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 computers with RSAT, Word 2010 and PowerShell 4.
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 
 \par \hich\af37\dbch\af31505\loch\f37 Version 1.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5853019 \hich\af37\dbch\af31505\loch\f37 35}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 
- of the script was tested on Windows 10 x64 with W\hich\af37\dbch\af31505\loch\f37 ord 2016 x64.
+ of the script was tested on Windows 10 x64 with Word 2016 x64.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11807305 \hich\af37\dbch\af31505\loch\f37 DHCP_Inventory_V1_}{\rtlch\fcs1 
-\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16342768 \hich\af37\dbch\af31505\loch\f37 4}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
+\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11807305 \hich\af37\dbch\af31505\loch\f37 DHCP_Inventory_V1
+\hich\af37\dbch\af31505\loch\f37 _}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16342768 \hich\af37\dbch\af31505\loch\f37 4}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
@@ -286,9 +287,9 @@ By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 For example, WEBDHCP01_DHCP_Inventory}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 .docx}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653\charrsid13987238 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash 
-\hich\af37\dbch\af31505\loch\f37 PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 DHCP server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11488686\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
+PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 DHCP server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 For example, WEBDHCP01_DHCP_Inventory}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 .pdf
@@ -304,7 +305,7 @@ By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid12196856\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 .\\}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11807305 
 \hich\af37\dbch\af31505\loch\f37 DHCP_Inventory_V1_}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16342768 \hich\af37\dbch\af31505\loch\f37 4}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856\charrsid13987238 
-\hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \loch\af37\dbch\af31505\hich\f37 \endash \loch\f37 ComputerName DHCP01 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \loch\af37\dbch\af31505\hich\f37 \endash \hich\af37\dbch\af31505\loch\f37 ComputerName DHCP01 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 DHCP01}{
@@ -314,7 +315,7 @@ By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15549553 \page }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13132957 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 PS C:\\Webster> get-help .\\
-dhcp_inventory_V1_4.ps1 -full                     \hich\af2\dbch\af31505\loch\f2                                             
+dhcp_inventory_V1_4.ps1 -full                                                                 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
 \par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1
 \par 
@@ -323,7 +324,7 @@ dhcp_inventory_V1_4.ps1 -full                     \hich\af2\dbch\af31505\loch\f2
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-MSWord] [-AddDateTime] [-AllDHCPServers]\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-MSWord] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 
@@ -332,43 +333,42 @@ dhcp_inventory_V1_4.ps1 -full                     \hich\af2\dbch\af31505\loch\f2
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Hardware] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid13132957 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-L\hich\af2\dbch\af31505\loch\f2 og]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webste\hich\af2\dbch\af31505\loch\f2 r\\dhcp_inventory_V1_4.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-AllDHCPServers]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  
 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String\hich\af2\dbch\af31505\loch\f2 >] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5588031 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev] [-Folder <String>] [-Hardware] [-IncludeLeases]}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-C\hich\af2\dbch\af31505\loch\f2 omputerName <String>] [-Dev] [-Folder <String>] [-Hardware] [-IncludeLeases]
+}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2     [-IncludeOptions] [-Log] [-ScriptInfo] [-UserName <String>] -SmtpServer <String> }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5588031 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 C:\\Webster\\dhcp_inventory_V1_4.ps1 [-HTML] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\W\hich\af2\dbch\af31505\loch\f2 ebster\\dhcp_inventory_V1_4.ps1 [-HTML] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-IncludeLeases] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-IncludeOptions] [-Log] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.\hich\af2\dbch\af31505\loch\f2 ps1 [-PDF] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_\hich\af2\dbch\af31505\loch\f2 4.ps1 [-PDF] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid288140 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-ComputerName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Hardw\hich\af2\dbch\af31505\loch\f2 
-are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>\hich\af2\dbch\af31505\loch\f2 
+] [-Hardware] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-Text] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [\hich\af2\dbch\af31505\loch\f2 -IncludeLeases] }{\rtlch\fcs1 \af2\afs18 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-\hich\af2\dbch\af31505\loch\f2 Hardware] [-IncludeLeases] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-IncludeOptions] [-Log] [-ScriptInfo] [<CommonParameters>]
 \par 
@@ -377,30 +377,30 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft 2012+ DHCP server using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text \hich\af2\dbch\af31505\loch\f2 or HTML file named after the DHCP server.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after the DHCP server.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Requires the DHCPServer module.
-\par \hich\af2\dbch\af31505\loch\f2     Can be run on a DHCP server or on a Windows 8.x or Windows 10 computer with RSAT installed.
+\par \hich\af2\dbch\af31505\loch\f2     Can be run\hich\af2\dbch\af31505\loch\f2  on a DHCP server or on a Windows 8.x or Windows 10 computer with RSAT installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=28972
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Window\hich\af2\dbch\af31505\loch\f2 s 8.1
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=39296
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Re\hich\af2\dbch\af31505\loch\f2 mote Server Administration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=45520
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 2008 R2, use the following to export and import the
+\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 2008 R2, use the\hich\af2\dbch\af31505\loch\f2  following to export and import the
 \par \hich\af2\dbch\af31505\loch\f2     DHCP data:
-\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, 20\hich\af2\dbch\af31505\loch\f2 08 or 2008 R2 server:
+\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, 2008 or 2008 R2 server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server export C:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Copy the C:\\DHCPExport.txt file to the 2012+ server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Import on the 2012+ server:
+\par \hich\af2\dbch\af31505\loch\f2         Import on\hich\af2\dbch\af31505\loch\f2  the 2012+ server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server import c:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The script can now be run on the 2012+ DHCP server to document the older DHCP
@@ -408,21 +408,21 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2008 and Server 2008 R2, the 2012+ DHCP Server PowerShell cmdlets
 \par \hich\af2\dbch\af31505\loch\f2     can be used for the export and import.
-\par \hich\af2\dbch\af31505\loch\f2         From the\hich\af2\dbch\af31505\loch\f2  2012+ DHCP server:
+\par \hich\af2\dbch\af31505\loch\f2         From the 2012+ DHCP server:
 \par \hich\af2\dbch\af31505\loch\f2                 Export-DhcpServer -ComputerName 2008R2Server.domain.tld -Leases -File
-\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               C:\\DHCPExport.xml
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Import-DhcpServer -ComputerName 2012Server.domain.tld -Leases -File
 \par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml -BackupPath C:\\dhcp\\backup\\
 \par 
-\par \hich\af2\dbch\af31505\loch\f2                 Note: The c:\\dhcp\\backup path must exist before the Import-DhcpServer
-\par \hich\af2\dbch\af31505\loch\f2                 cmdlet \hich\af2\dbch\af31505\loch\f2 is run.
+\par \hich\af2\dbch\af31505\loch\f2                 Note: The c:\\dhcp\\backup path must exist before the Import-D\hich\af2\dbch\af31505\loch\f2 hcpServer
+\par \hich\af2\dbch\af31505\loch\f2                 cmdlet is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using netsh is much faster than using the PowerShell export and import cmdlets.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Processing of IPv4 Multicast Scopes is only available with Server 2012 R2 DHCP.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover Page, Table of Contents and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover P\hich\af2\dbch\af31505\loch\f2 age, Table of Contents and Footer.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
@@ -433,10 +433,10 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
-\par \hich\af2\dbch\af31505\loch\f2         Norwegian
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -445,50 +445,37 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set\hich\af2\dbch\af31505\loch\f2  True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  f\hich\af2\dbch\af31505\loch\f2 alse
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be ins\hich\af2\dbch\af31505\loch\f2 talled.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to\hich\af2\dbch\af31505\loch\f2  the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by defa\hich\af2\dbch\af31505\loch\f2 ult.
+\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -496,42 +483,55 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AllDHCPServers [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800\hich\af2\dbch\af31505\loch\f2 .docx (or .pdf or .txt).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AllDHCPServers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         The script will process all Authorized DHCP servers that are online.
-\par \hich\af2\dbch\af31505\loch\f2         "All DHCP Servers" is used for the report title.
+\par \hich\af2\dbch\af31505\loch\f2         "All DHCP Servers" is used for the report ti\hich\af2\dbch\af31505\loch\f2 tle.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ALL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                \hich\af2\dbch\af31505\loch\f2     named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address fi\hich\af2\dbch\af31505\loch\f2 eld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Addre\hich\af2\dbch\af31505\loch\f2 ss field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
@@ -539,27 +539,27 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -567,13 +567,13 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -581,86 +581,86 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid wi\hich\af2\dbch\af31505\loch\f2 th the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <\hich\af2\dbch\af31505\loch\f2 String>
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
-\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. \hich\af2\dbch\af31505\loch\f2 Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. W\hich\af2\dbch\af31505\loch\f2 orks)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Au\hich\af2\dbch\af31505\loch\f2 thor fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Wor\hich\af2\dbch\af31505\loch\f2 ks if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. W\hich\af2\dbch\af31505\loch\f2 orks in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top d\hich\af2\dbch\af31505\loch\f2 ate doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sidel\hich\af2\dbch\af31505\loch\f2 ine.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Side\hich\af2\dbch\af31505\loch\f2 line
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         DHCP server to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         The computername is used for the report title.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is deter\hich\af2\dbch\af31505\loch\f2 mined and used.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered\hich\af2\dbch\af31505\loch\f2  as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
+\par \hich\af2\dbch\af31505\loch\f2         I\hich\af2\dbch\af31505\loch\f2 f both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -669,14 +669,14 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more\hich\af2\dbch\af31505\loch\f2  troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter i\hich\af2\dbch\af31505\loch\f2 s disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value\hich\af2\dbch\af31505\loch\f2                 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -684,40 +684,40 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Po\hich\af2\dbch\af31505\loch\f2 sition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Proces\hich\af2\dbch\af31505\loch\f2 sor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it t\hich\af2\dbch\af31505\loch\f2 akes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeLeases [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Include DHCP lease information.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default is to not included lease information.
+\par \hich\af2\dbch\af31505\loch\f2         Default is to not included lease information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -IncludeOptions [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Include DHCP Options information.
@@ -725,9 +725,9 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
@@ -735,32 +735,32 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter i\hich\af2\dbch\af31505\loch\f2 s disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wi\hich\af2\dbch\af31505\loch\f2 ldcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and \hich\af2\dbch\af31505\loch\f2 Footer.
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
@@ -769,8 +769,8 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -778,8 +778,8 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -788,7 +788,7 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -797,9 +797,9 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?             \hich\af2\dbch\af31505\loch\f2        named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
@@ -807,16 +807,16 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariab\hich\af2\dbch\af31505\loch\f2 le, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/g\hich\af2\dbch\af31505\loch\f2 o.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
@@ -830,23 +830,24 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NAME: DHCP_Inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2         NAME: DHCP_Inv\hich\af2\dbch\af31505\loch\f2 entory_V1_4.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.43
-\par \hich\af2\dbch\af31505\loch\f2         AU\hich\af2\dbch\af31505\loch\f2 THOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: April 15, 2020
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: April 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6317044 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
+\hich\af2\dbch\af31505\loch\f2 , 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HK\hich\af2\dbch\af31505\loch\f2 EY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="\hich\af2\dbch\af31505\loch\f2 Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
@@ -854,44 +855,44 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName localhost
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Script will resolve localhost to $env:computername, for example DHCPServer01.
+\par \hich\af2\dbch\af31505\loch\f2     Script will resolve localhost to $env:computername, for example DHCPServer01.
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01 and not localhost.
-\par \hich\af2\dbch\af31505\loch\f2     Output file name will use the server name DHCPServer01 and not localhost.
+\par \hich\af2\dbch\af31505\loch\f2     Output file name will use the server name DHCPSe\hich\af2\dbch\af31505\loch\f2 rver01 and not localhost.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName 192.168.1.222
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\C\hich\af2\dbch\af31505\loch\f2 ommon\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Ad\hich\af2\dbch\af31505\loch\f2 ministrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will resolve 192.168.1.222 to the DNS hostname, for example DHCPServer01.
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01 and not 192.18.1.222.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Output file name will use the server name DHCPServer01 and not 192.168.1.222.
+\par \hich\af2\dbch\af31505\loch\f2     Output file name will use the server name DHCPSe\hich\af2\dbch\af31505\loch\f2 rver01 and not 192.168.1.222.
 \par 
 \par 
 \par 
@@ -919,7 +920,7 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Text -ComputerName DHCPServer02
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely again\hich\af2\dbch\af31505\loch\f2 st DHCP server DHCPServer02.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
 \par 
 \par 
@@ -933,33 +934,33 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPL\hich\af2\dbch\af31505\loch\f2 E 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -MSWord -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a Word DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Com\hich\af2\dbch\af31505\loch\f2 panyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for th\hich\af2\dbch\af31505\loch\f2 e User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------------------\hich\af2\dbch\af31505\loch\f2  EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Hardware -ComputerName DHCPServer02
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -Hardware -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -971,7 +972,7 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -HTML -ComputerName DHCPServer02
 \par 
@@ -984,16 +985,16 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer03 -IncludeLeases}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer03.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP ser\hich\af2\dbch\af31505\loch\f2 ver DHCPServer03.
 \par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease information.
 \par 
 \par 
@@ -1003,23 +1004,23 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -AllDHCPServer -HTML -IncludeOptions
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will find all Authorized DHCP servers and will process all servers that are }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     The script will find all Aut\hich\af2\dbch\af31505\loch\f2 horized DHCP servers and will process all servers that are }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 online.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Output will contains DHCP Options information.
+\par \hich\af2\dbch\af31505\loch\f2     Output will contains DHCP Options information.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webst\hich\af2\dbch\af31505\loch\f2 er" -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Car\hich\af2\dbch\af31505\loch\f2 l Webster for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
 \par 
@@ -1028,49 +1029,49 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CN "Carl Webster Consulting" -CP \hich\af2\dbch\af31505\loch\f2 "Mod"
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -ComputerName DHCPServer02 -IncludeLeases
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl \hich\af2\dbch\af31505\loch\f2 Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
-\par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease i\hich\af2\dbch\af31505\loch\f2 nformation.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Script will be run remotely against DHCP server DHCPServer02.
+\par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease information.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221\hich\af2\dbch\af31505\loch\f2 B Baker Street, London, England"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2     Will us\hich\af2\dbch\af31505\loch\f2 e:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        +44 1753 276200 for the Company Phone.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -UserName "D\hich\af2\dbch\af31505\loch\f2 r. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Will use:
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
@@ -1084,14 +1085,14 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName\hich\af2\dbch\af31505\loch\f2 ="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_\hich\af2\dbch\af31505\loch\f2 CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User N\hich\af2\dbch\af31505\loch\f2 ame.
+\par \hich\af2\dbch\af31505\loch\f2     Si\hich\af2\dbch\af31505\loch\f2 deline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
@@ -1102,12 +1103,12 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.\hich\af2\dbch\af31505\loch\f2 tld
+\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  The script will use the email server mailrelay.domain.tld, sending from
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
@@ -1119,29 +1120,29 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/2956491?hl=en
 \par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/176600?hl=en
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" opti\hich\af2\dbch\af31505\loch\f2 on on your account.
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-sui\hich\af2\dbch\af31505\loch\f2 te account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default v\hich\af2\dbch\af31505\loch\f2 alues.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for t\hich\af2\dbch\af31505\loch\f2 he User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V1_4.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
@@ -1149,9 +1150,9 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1160,9 +1161,9 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will \hich\af2\dbch\af31505\loch\f2 use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's cre\hich\af2\dbch\af31505\loch\f2 dentials are not valid to send email, the user will be prompted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
 \par 
 \par 
@@ -1172,16 +1173,16 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
+\par \hich\af2\dbch\af31505\loch\f2     -Smtp\hich\af2\dbch\af31505\loch\f2 Server smtp.office365.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -Fr\hich\af2\dbch\af31505\loch\f2 om Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1190,16 +1191,16 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     *** NOTE **\hich\af2\dbch\af31505\loch\f2 *
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
-\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
-\par \hich\af2\dbch\af31505\loch\f2     t\hich\af2\dbch\af31505\loch\f2 o enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will \hich\af2\dbch\af31505\loch\f2 be prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
 \par 
 \par 
 \par 
@@ -1209,17 +1210,17 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Admini\hich\af2\dbch\af31505\loch\f2 strator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the scr\hich\af2\dbch\af31505\loch\f2 ipt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
@@ -1230,18 +1231,18 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its
-\par \hich\af2\dbch\af31505\loch\f2     hardware.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     hardw\hich\af2\dbch\af31505\loch\f2 are.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compan\hich\af2\dbch\af31505\loch\f2 y Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1272,20 +1273,20 @@ are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -AllDHCPServers
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -AllDHCPServers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Even though DHCPServer01 is specified, the script will find all Authorized DHCP servers
-\par \hich\af2\dbch\af31505\loch\f2     and will\hich\af2\dbch\af31505\loch\f2  process all servers that are online.
+\par \hich\af2\dbch\af31505\loch\f2     Even though DHCPServer01 is specified, the script will find all Author\hich\af2\dbch\af31505\loch\f2 ized DHCP servers
+\par \hich\af2\dbch\af31505\loch\f2     and will process all servers that are online.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -1408,8 +1409,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d0af
-13de4d13d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000060e1
+9342e313d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DHCP_Inventory_V1_4_ReadMe.rtf
+++ b/DHCP_Inventory_V1_4_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -92,12 +92,12 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid223821
-\rsid288140\rsid1860407\rsid3830441\rsid4810367\rsid5384286\rsid5588031\rsid5853019\rsid6317044\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030\rsid11807305
-\rsid12196856\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768\rsid16463664}
-{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy16\hr6\min36}{\version28}{\edmins184}
-{\nofpages20}{\nofwords5546}{\nofchars31614}{\nofcharsws37086}{\vern125}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid288140\rsid1860407\rsid3830441\rsid4409828\rsid4810367\rsid5384286\rsid5588031\rsid5853019\rsid6317044\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030
+\rsid11807305\rsid12196856\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768
+\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy16\hr14\min27}
+{\version29}{\edmins188}{\nofpages20}{\nofwords5568}{\nofchars31739}{\nofcharsws37233}{\vern125}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzI3NTQ0NzA3NDA2NTFX0lEKTi0uzszPAykwqgUADQCtHiwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -234,13 +234,12 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools fo\hich\af37\dbch\af31505\loch\f37 r Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11602030 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e0000000069}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e44007300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e4400730055}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -248,8 +247,8 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f0034}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
-\hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for \hich\af43\dbch\af31505\loch\f43 Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f003432}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
+\hich\af43\dbch\af31505\loch\f43 R\hich\af43\dbch\af31505\loch\f43 emote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 4.\tab}\hich\af37\dbch\af31505\loch\f37 The DHCPServer module is required.
@@ -291,8 +290,8 @@ By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \
 PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 DHCP server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 For example, WEBDHCP01_DHCP_Inventory}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 .pdf
+\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 F\hich\af37\dbch\af31505\loch\f37 
+or example, WEBDHCP01_DHCP_Inventory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 .pdf
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid136639\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 TEXT}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid136639\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid136639 \hich\af37\dbch\af31505\loch\f37 formatted text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -314,17 +313,20 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15549553 \page }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13132957 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 PS C:\\Webster> get-help .\\
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13132957 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 PS }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 > get-help .\\
 dhcp_inventory_V1_4.ps1 -full                                                                 
 \par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_4.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft 2012+ DHCP server.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-MSWord] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_4.ps1 [-MSWord] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 
@@ -336,7 +338,8 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webste\hich\af2\dbch\af31505\loch\f2 r\\dhcp_inventory_V1_4.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_4.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-AllDHCPServers]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  
 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
@@ -348,13 +351,15 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\W\hich\af2\dbch\af31505\loch\f2 ebster\\dhcp_inventory_V1_4.ps1 [-HTML] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_4.ps1 [-HTML] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-IncludeLeases] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-IncludeOptions] [-Log] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_\hich\af2\dbch\af31505\loch\f2 4.ps1 [-PDF] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_\hich\af2\dbch\af31505\loch\f2 4.ps1 [-PDF] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 
@@ -366,7 +371,8 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-Text] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \\\hich\af2\dbch\af31505\loch\f2 
+dhcp_inventory_V1_4.ps1 [-Text] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-\hich\af2\dbch\af31505\loch\f2 Hardware] [-IncludeLeases] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid288140 
@@ -379,28 +385,28 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after the DHCP server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script requires at least PowerShell version 3 but runs best in version 5.
+\par \hich\af2\dbch\af31505\loch\f2     Script requires at least PowerShell version\hich\af2\dbch\af31505\loch\f2  3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Requires the DHCPServer module.
-\par \hich\af2\dbch\af31505\loch\f2     Can be run\hich\af2\dbch\af31505\loch\f2  on a DHCP server or on a Windows 8.x or Windows 10 computer with RSAT installed.
+\par \hich\af2\dbch\af31505\loch\f2     Can be run on a DHCP server or on a Windows 8.x or Windows 10 computer with RSAT installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
-\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=28972
+\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us\hich\af2\dbch\af31505\loch\f2 /download/details.aspx?id=28972
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Window\hich\af2\dbch\af31505\loch\f2 s 8.1
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=39296
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
-\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=45520
+\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/down\hich\af2\dbch\af31505\loch\f2 load/details.aspx?id=45520
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 2008 R2, use the\hich\af2\dbch\af31505\loch\f2  following to export and import the
+\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 2008 R2, use the following to export and import the
 \par \hich\af2\dbch\af31505\loch\f2     DHCP data:
 \par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, 2008 or 2008 R2 server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server export C:\\DHCPExport.txt all
 \par 
-\par \hich\af2\dbch\af31505\loch\f2                 Copy the C:\\DHCPExport.txt file to the 2012+ server.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Copy the C:\\DHCPExport.txt file to the 2012+ server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Import on\hich\af2\dbch\af31505\loch\f2  the 2012+ server:
+\par \hich\af2\dbch\af31505\loch\f2         Import on the 2012+ server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server import c:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The script can now be run on the 2012+ DHCP server to document the older DHCP
@@ -408,32 +414,32 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2008 and Server 2008 R2, the 2012+ DHCP Server PowerShell cmdlets
 \par \hich\af2\dbch\af31505\loch\f2     can be used for the export and import.
-\par \hich\af2\dbch\af31505\loch\f2         From the 2012+ DHCP server:
+\par \hich\af2\dbch\af31505\loch\f2         From the\hich\af2\dbch\af31505\loch\f2  2012+ DHCP server:
 \par \hich\af2\dbch\af31505\loch\f2                 Export-DhcpServer -ComputerName 2008R2Server.domain.tld -Leases -File
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               C:\\DHCPExport.xml
+\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Import-DhcpServer -ComputerName 2012Server.domain.tld -Leases -File
-\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml -BackupPath C:\\dhcp\\backup\\
+\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.x\hich\af2\dbch\af31505\loch\f2 ml -BackupPath C:\\dhcp\\backup\\
 \par 
-\par \hich\af2\dbch\af31505\loch\f2                 Note: The c:\\dhcp\\backup path must exist before the Import-D\hich\af2\dbch\af31505\loch\f2 hcpServer
+\par \hich\af2\dbch\af31505\loch\f2                 Note: The c:\\dhcp\\backup path must exist before the Import-DhcpServer
 \par \hich\af2\dbch\af31505\loch\f2                 cmdlet is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using netsh is much faster than using the PowerShell export and import cmdlets.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Processing of IPv4 Multicast Scopes is only available with Server 2012 R2 DHCP.
+\par \hich\af2\dbch\af31505\loch\f2     Processing of IPv\hich\af2\dbch\af31505\loch\f2 4 Multicast Scopes is only available with Server 2012 R2 DHCP.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover P\hich\af2\dbch\af31505\loch\f2 age, Table of Contents and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover Page, Table of Contents and Footer.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
-\par \hich\af2\dbch\af31505\loch\f2         Danish
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Norwegian
+\par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
 \par \hich\af2\dbch\af31505\loch\f2         Swedish
@@ -441,24 +447,24 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML f\hich\af2\dbch\af31505\loch\f2 ile with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set\hich\af2\dbch\af31505\loch\f2  True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  f\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
@@ -467,15 +473,15 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatt\hich\af2\dbch\af31505\loch\f2 ed text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -483,11 +489,11 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800\hich\af2\dbch\af31505\loch\f2 .docx (or .pdf or .txt).
+\par \hich\af2\dbch\af31505\loch\f2         Out\hich\af2\dbch\af31505\loch\f2 put filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -498,55 +504,55 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AllDHCPServers [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         The script will process all Authorized DHCP servers that are online.
-\par \hich\af2\dbch\af31505\loch\f2         "All DHCP Servers" is used for the report ti\hich\af2\dbch\af31505\loch\f2 tle.
+\par \hich\af2\dbch\af31505\loch\f2         "\hich\af2\dbch\af31505\loch\f2 All DHCP Servers" is used for the report title.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ALL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                \hich\af2\dbch\af31505\loch\f2     named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address fi\hich\af2\dbch\af31505\loch\f2 eld.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover\hich\af2\dbch\af31505\loch\f2  Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/\hich\af2\dbch\af31505\loch\f2 2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
@@ -555,27 +561,27 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with th\hich\af2\dbch\af31505\loch\f2 e MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
@@ -634,30 +640,30 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date d\hich\af2\dbch\af31505\loch\f2 oesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Sidel\hich\af2\dbch\af31505\loch\f2 ine.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias\hich\af2\dbch\af31505\loch\f2  of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Side\hich\af2\dbch\af31505\loch\f2 line
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?     \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         DHCP server to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         The computername is used for the report title.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered\hich\af2\dbch\af31505\loch\f2  as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or\hich\af2\dbch\af31505\loch\f2  IP Address.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         I\hich\af2\dbch\af31505\loch\f2 f both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
+\par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers a\hich\af2\dbch\af31505\loch\f2 re used, AllDHCPServers is used.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -828,15 +834,17 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DHCP_Inv\hich\af2\dbch\af31505\loch\f2 entory_V1_4.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.43
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
 \par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: April 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6317044 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
 \hich\af2\dbch\af31505\loch\f2 , 2020
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 
+\par 
+\par 
+\par 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01
 \par 
@@ -925,7 +933,7 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----\hich\af2\dbch\af31505\loch\f2 ---------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -HTML -ComputerName DHCPServer02
 \par 
@@ -934,19 +942,19 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPL\hich\af2\dbch\af31505\loch\f2 E 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -MSWord -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a Word DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Com\hich\af2\dbch\af31505\loch\f2 panyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName\hich\af2\dbch\af31505\loch\f2 ="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for th\hich\af2\dbch\af31505\loch\f2 e User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User N\hich\af2\dbch\af31505\loch\f2 ame.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
@@ -1006,7 +1014,7 @@ dhcp_inventory_V1_4.ps1 -full
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will find all Aut\hich\af2\dbch\af31505\loch\f2 horized DHCP servers and will process all servers that are }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 online.
-\par \hich\af2\dbch\af31505\loch\f2     Output will contains DHCP Options information.
+\par \hich\af2\dbch\af31505\loch\f2     Output will contain\hich\af2\dbch\af31505\loch\f2  DHCP Options information.
 \par 
 \par 
 \par 
@@ -1014,7 +1022,6 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting"
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
@@ -1117,8 +1124,16 @@ dhcp_inventory_V1_4.ps1 -full
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/2956491?hl=en
-\par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/176600?hl=en
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid13132957\charrsid4409828 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4409828 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid13132957\charrsid4409828 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-sui\hich\af2\dbch\af31505\loch\f2 te account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
@@ -1409,8 +1424,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000060e1
-9342e313d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000a0a5
+710f2514d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DHCP_Inventory_V1_4_ReadMe.rtf
+++ b/DHCP_Inventory_V1_4_ReadMe.rtf
@@ -1,8 +1,8 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri{\*\falt Calibri};}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
@@ -92,13 +92,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1098217346\listoverridecount0\ls5}}{\*\rsidtbl \rsid136639\rsid223821
-\rsid1860407\rsid3830441\rsid4810367\rsid5384286\rsid5853019\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030\rsid11807305\rsid12196856\rsid12916989\rsid13133162
-\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768\rsid16463664}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy17\hr9}{\version25}{\edmins160}{\nofpages18}{\nofwords5193}{\nofchars29604}
-{\nofcharsws34728}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid288140\rsid1860407\rsid3830441\rsid4810367\rsid5384286\rsid5588031\rsid5853019\rsid6557588\rsid7553723\rsid7885078\rsid9334467\rsid9460937\rsid9531606\rsid10290913\rsid10816165\rsid11142684\rsid11488686\rsid11602030\rsid11807305\rsid12196856
+\rsid12916989\rsid13132957\rsid13133162\rsid13649097\rsid13706967\rsid13716610\rsid13835364\rsid13987238\rsid14365751\rsid14369692\rsid14697282\rsid14893653\rsid15008361\rsid15549553\rsid16057654\rsid16149376\rsid16342768\rsid16463664}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy15\hr12\min47}{\version27}{\edmins183}
+{\nofpages20}{\nofwords5546}{\nofchars31614}{\nofcharsws37086}{\vern125}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzI3NTQ0NzA3NDA2NTFX0lEKTi0uzszPAykwrAUAzlOANSwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzI3NTQ0NzA3NDA2NTFX0lEKTi0uzszPAykwqgUADQCtHiwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -213,6 +213,7 @@ NOTE: This script }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid11807305 \hic
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid14365751 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Statistics
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid14365751 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls5\ilvl1\rin0\lin1440\itap0\pararsid14365751 {\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14365751 \hich\af31506\dbch\af31505\loch\f31506 Server Options
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid13132957 \hich\af2\dbch\af31505\loch\f2 o\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid13132957 \hich\af31506\dbch\af31505\loch\f31506 DHCP Options
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14365751 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14365751 
 \par }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid14365751\charrsid10290913 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913 
@@ -233,12 +234,12 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid11602030\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000004c00ff000000000000000000006e000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e4400}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000064494200000000900000000000000000ff006e440073}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -246,7 +247,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12196856 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000000000000000000000cf004f00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid12196856 
 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12196856\charrsid12196856 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15008361 \hich\af37\dbch\af31505\loch\f37 PowerShell 3.0 or higher is required.
@@ -312,69 +313,71 @@ By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15549553 \page }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16342768 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16342768\charrsid16342768 \hich\af2\dbch\af31505\loch\f2 PS C:\\ScriptTesting> get-help .\\
-dhcp_inventory_V1_4.ps1 -full
-\par 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14369692 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 PS }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 > get-help .\\dhcp_inventory_V1_4.ps1 -full
-\par 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid13132957 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 PS C:\\Webster> get-help .\\
+dhcp_inventory_V1_4.ps1 -full                     \hich\af2\dbch\af31505\loch\f2                                             
 \par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft 2012+ DHCP server.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-AddDateTime] [-MSWord] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>] [-UserName }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 <String>] [-Compu\hich\af2\dbch\af31505\loch\f2 
-terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
-\par \hich\af2\dbch\af31505\loch\f2     [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-MSWord] [-AddDateTime] [-AllDHCPServers]\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid13132957 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-ComputerName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Hardware] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-L\hich\af2\dbch\af31505\loch\f2 og]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-AddDateTime] [-HTML] [-MSWord] [-PDF] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-Text] [-AllDHCPServers] [-CompanyAddress <String>] [-Co\hich\af2\dbch\af31505\loch\f2 mpanyEmail <String>] }
-{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 <String>] [-UserName <String>] [-ComputerName <String>] [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     [-Hardware] [-IncludeLeases] -SmtpServer <String> [-SmtpPort <Int32>] [-\hich\af2\dbch\af31505\loch\f2 UseSSL] -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 <String> -To <String> [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-HTML] [-MSWord] [-PDF] [-Text] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-AllDHCPServers]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  
+}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyName <String>] [-CompanyPhone}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String\hich\af2\dbch\af31505\loch\f2 >] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev] [-Folder <String>] [-Hardware] [-IncludeLeases]}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5588031 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2     [-IncludeOptions] [-Log] [-ScriptInfo] [-UserName <String>] -SmtpServer <String> }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5588031 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5588031 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -From <String> -To <String> [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-AddDateTime] [-HTML] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases] [-Dev] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-ScriptIn\hich\af2\dbch\af31505\loch\f2 fo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 C:\\Webster\\dhcp_inventory_V1_4.ps1 [-HTML] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [-IncludeLeases] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-IncludeOptions] [-Log] [-ScriptInfo] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-AddDateTime] [-PDF] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>] [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage <String>\hich\af2\dbch\af31505\loch\f2 
-] [-UserName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 <String>] [-ComputerName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
-\par \hich\af2\dbch\af31505\loch\f2     [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.\hich\af2\dbch\af31505\loch\f2 ps1 [-PDF] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid288140 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-ComputerName }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder <String>] [-Hardw\hich\af2\dbch\af31505\loch\f2 
+are] [-IncludeLeases] [-IncludeOptions] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Log]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-UserName <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2 C:\\ScriptTesting}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \\
-\hich\af2\dbch\af31505\loch\f2 dhcp_inventory_V1_4.ps1 [-AddDateTime] [-Text] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [\hich\af2\dbch\af31505\loch\f2 
--Folder <String>] [-Hardware] [-IncludeLeases] [-Dev] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\Webster\\dhcp_inventory_V1_4.ps1 [-Text] [-AddDateTime] [-AllDHCPServers] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-Dev]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid288140 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Hardware] [\hich\af2\dbch\af31505\loch\f2 -IncludeLeases] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid288140 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 [-IncludeOptions] [-Log] [-ScriptInfo] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft 2012+ DHCP server using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or\hich\af2\dbch\af31505\loch\f2  PDF document, text or HTML file named after the DHCP server.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text \hich\af2\dbch\af31505\loch\f2 or HTML file named after the DHCP server.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script requires at least PowerShell version 3 but runs best in version 5.
 \par 
@@ -384,40 +387,40 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=28972
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration To\hich\af2\dbch\af31505\loch\f2 ols for Windows 8.1
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=39296
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
+\par \hich\af2\dbch\af31505\loch\f2     Re\hich\af2\dbch\af31505\loch\f2 mote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=45520
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 20\hich\af2\dbch\af31505\loch\f2 08 R2, use the following to export and import the
+\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2003, 2008 and 2008 R2, use the following to export and import the
 \par \hich\af2\dbch\af31505\loch\f2     DHCP data:
-\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, 2008 or 2008 R2 server:
+\par \hich\af2\dbch\af31505\loch\f2         Export from the 2003, 20\hich\af2\dbch\af31505\loch\f2 08 or 2008 R2 server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server export C:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Copy the C:\\DHCPExport.txt file to the 2012+ server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Import on the 2012+ server:
+\par \hich\af2\dbch\af31505\loch\f2         Import on the 2012+ server:
 \par \hich\af2\dbch\af31505\loch\f2                 netsh dhcp server import c:\\DHCPExport.txt all
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The script can now be run on the 2012+ DHCP server to document the older DHCP
 \par \hich\af2\dbch\af31505\loch\f2         information.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2008 and Server 2008 R2, the\hich\af2\dbch\af31505\loch\f2  2012+ DHCP Server PowerShell cmdlets
+\par \hich\af2\dbch\af31505\loch\f2     For Windows Server 2008 and Server 2008 R2, the 2012+ DHCP Server PowerShell cmdlets
 \par \hich\af2\dbch\af31505\loch\f2     can be used for the export and import.
-\par \hich\af2\dbch\af31505\loch\f2         From the 2012+ DHCP server:
+\par \hich\af2\dbch\af31505\loch\f2         From the\hich\af2\dbch\af31505\loch\f2  2012+ DHCP server:
 \par \hich\af2\dbch\af31505\loch\f2                 Export-DhcpServer -ComputerName 2008R2Server.domain.tld -Leases -File
 \par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Import-DhcpServer -ComputerName 2012Server.domain.tld -Leases -File
-\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml -BackupPath C:\\dh\hich\af2\dbch\af31505\loch\f2 cp\\backup\\
+\par \hich\af2\dbch\af31505\loch\f2                 C:\\DHCPExport.xml -BackupPath C:\\dhcp\\backup\\
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Note: The c:\\dhcp\\backup path must exist before the Import-DhcpServer
-\par \hich\af2\dbch\af31505\loch\f2                 cmdlet is run.
+\par \hich\af2\dbch\af31505\loch\f2                 cmdlet \hich\af2\dbch\af31505\loch\f2 is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using netsh is much faster than using the PowerShell export and import cmdlets.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Processing of IPv4 Multicast Scopes i\hich\af2\dbch\af31505\loch\f2 s only available with Server 2012 R2 DHCP.
+\par \hich\af2\dbch\af31505\loch\f2     Processing of IPv4 Multicast Scopes is only available with Server 2012 R2 DHCP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Documents include a Cover Page, Table of Contents and Footer.
 \par 
@@ -425,7 +428,7 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 utch
+\par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
@@ -433,49 +436,36 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2         Swedish
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
-\par \hich\af2\dbch\af31505\loch\f2         T\hich\af2\dbch\af31505\loch\f2 his parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -HTML [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word Save\hich\af2\dbch\af31505\loch\f2 As PDF capability.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be ins\hich\af2\dbch\af31505\loch\f2 talled.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -483,94 +473,107 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to\hich\af2\dbch\af31505\loch\f2  the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by defa\hich\af2\dbch\af31505\loch\f2 ult.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AllDHCPServers [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -AllDHCPServers [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
 \par \hich\af2\dbch\af31505\loch\f2         The script will process all Authorized DHCP servers that are online.
 \par \hich\af2\dbch\af31505\loch\f2         "All DHCP Servers" is used for the report title.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers i\hich\af2\dbch\af31505\loch\f2 s used.
+\par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ALL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Addre\hich\af2\dbch\af31505\loch\f2 ss field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast\hich\af2\dbch\af31505\loch\f2  (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Em\hich\af2\dbch\af31505\loch\f2 ail field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover P\hich\af2\dbch\af31505\loch\f2 age has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -578,7 +581,7 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
@@ -588,52 +591,52 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <\hich\af2\dbch\af31505\loch\f2 String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. \hich\af2\dbch\af31505\loch\f2 Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Wor\hich\af2\dbch\af31505\loch\f2 ks if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 ma\hich\af2\dbch\af31505\loch\f2 nually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2\hich\af2\dbch\af31505\loch\f2 010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word\hich\af2\dbch\af31505\loch\f2  2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
@@ -646,32 +649,35 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias\hich\af2\dbch\af31505\loch\f2  of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         DHCP server to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         The computername is used for the report title.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localho\hich\af2\dbch\af31505\loch\f2 st or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is deter\hich\af2\dbch\af31505\loch\f2 mined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter i\hich\af2\dbch\af31505\loch\f2 s disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
@@ -680,18 +686,18 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This paramet\hich\af2\dbch\af31505\loch\f2 er may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 may require the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time i\hich\af2\dbch\af31505\loch\f2 t takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it t\hich\af2\dbch\af31505\loch\f2 akes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -713,82 +719,15 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
-\par \hich\af2\dbch\af31505\loch\f2         Default is 25.
+\par \hich\af2\dbch\af31505\loch\f2     -IncludeOptions [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Include DHCP Options information.
+\par \hich\af2\dbch\af31505\loch\f2         Default is to not included Options information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
-\par \hich\af2\dbch\af31505\loch\f2         Default is False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for\hich\af2\dbch\af31505\loch\f2  the From email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all e\hich\af2\dbch\af31505\loch\f2 rrors to a text file at the end of the script.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fal\hich\af2\dbch\af31505\loch\f2 se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
@@ -799,10 +738,84 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and \hich\af2\dbch\af31505\loch\f2 Footer.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?        \hich\af2\dbch\af31505\loch\f2             named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Default is 25.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Default is False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -To <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable.\hich\af2\dbch\af31505\loch\f2  For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariab\hich\af2\dbch\af31505\loch\f2 le, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
@@ -810,7 +823,7 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF, HT\hich\af2\dbch\af31505\loch\f2 ML or
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF, HTML or
 \par \hich\af2\dbch\af31505\loch\f2     formatted text document.
 \par 
 \par 
@@ -818,22 +831,22 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: DHCP_Inventory_V1_4.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.42
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster\hich\af2\dbch\af31505\loch\f2  and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: December 17, 2019
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.43
+\par \hich\af2\dbch\af31505\loch\f2         AU\hich\af2\dbch\af31505\loch\f2 THOR: Carl Webster and Michael B. Smith
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: April 15, 2020
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Car\hich\af2\dbch\af31505\loch\f2 l
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     HK\hich\af2\dbch\af31505\loch\f2 EY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
@@ -847,55 +860,55 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will resolve localhost to $env:computername, for example DHC\hich\af2\dbch\af31505\loch\f2 PServer01.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Script will resolve localhost to $env:computername, for example DHCPServer01.
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01 and not localhost.
 \par \hich\af2\dbch\af31505\loch\f2     Output file name will use the server name DHCPServer01 and not localhost.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName 192.168.1.222
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName 192.168.1.222
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will r\hich\af2\dbch\af31505\loch\f2 esolve 192.168.1.222 to the DNS hostname, for example DHCPServer01.
+\par \hich\af2\dbch\af31505\loch\f2     Script will resolve 192.168.1.222 to the DNS hostname, for example DHCPServer01.
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01 and not 192.18.1.222.
-\par \hich\af2\dbch\af31505\loch\f2     Output file name will use the server name DHCPServer01 and not 192.168.1.222.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Output file name will use the server name DHCPServer01 and not 192.168.1.222.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------\hich\af2\dbch\af31505\loch\f2 --------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -PDF -ComputerName DHCPServer02
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default \hich\af2\dbch\af31505\loch\f2 values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Adminis\hich\af2\dbch\af31505\loch\f2 trator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Adminis\hich\af2\dbch\af31505\loch\f2 trator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
@@ -906,51 +919,51 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Text -ComputerName DHCPServer02
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely again\hich\af2\dbch\af31505\loch\f2 st DHCP server DHCPServer02.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_\hich\af2\dbch\af31505\loch\f2 V1_4.ps1 -HTML -ComputerName DHCPServer02
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -HTML -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -MSWord -ComputerName DHCPSe\hich\af2\dbch\af31505\loch\f2 rver02
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -MSWord -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a Word DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webst\hich\af2\dbch\af31505\loch\f2 er"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will b\hich\af2\dbch\af31505\loch\f2 e run remotely against DHCP server DHCPServer02.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------------------\hich\af2\dbch\af31505\loch\f2  EXAMPLE 8 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Hardware -ComputerName DHCPServer02
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
@@ -967,20 +980,20 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPL\hich\af2\dbch\af31505\loch\f2 E 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer03 -IncludeLeases
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer03 -IncludeLeases}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server D\hich\af2\dbch\af31505\loch\f2 HCPServer03.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer03.
 \par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease information.
 \par 
 \par 
@@ -988,43 +1001,53 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster\hich\af2\dbch\af31505\loch\f2  Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  
-
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster\hich\af2\dbch\af31505\loch\f2 " -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -AllDHCPServer -HTML -IncludeOptions
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Co\hich\af2\dbch\af31505\loch\f2 ver Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster\hich\af2\dbch\af31505\loch\f2  for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
+\par \hich\af2\dbch\af31505\loch\f2     The script will find all Authorized DHCP servers and will process all servers that are }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 online.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Output will contains DHCP Options information.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CN "C\hich\af2\dbch\af31505\loch\f2 arl Webster\hich\af2\dbch\af31505\loch\f2  Consulting" -CP "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 
-\hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster\hich\af2\dbch\af31505\loch\f2 " -ComputerName DHCPServer02 -IncludeLeases
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webst\hich\af2\dbch\af31505\loch\f2 er" -ComputerName DHCPServer01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster\hich\af2\dbch\af31505\loch\f2  Consulting for the Company Name (alias CN).
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster\hich\af2\dbch\af31505\loch\f2  for t\hich\af2\dbch\af31505\loch\f2 he User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
-\par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease information.
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+\par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster" -ComputerName DHCPServer02 -IncludeLeases
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Carl \hich\af2\dbch\af31505\loch\f2 Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer02.
+\par \hich\af2\dbch\af31505\loch\f2     Output will contain DHCP lease i\hich\af2\dbch\af31505\loch\f2 nformation.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, \hich\af2\dbch\af31505\loch\f2 London, England"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221\hich\af2\dbch\af31505\loch\f2 B Baker Street, London, England"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
@@ -1032,111 +1055,171 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Ba\hich\af2\dbch\af31505\loch\f2 ker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------\hich\af2\dbch\af31505\loch\f2 -------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inve\hich\af2\dbch\af31505\loch\f2 ntory_V1_4.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     Consulting"
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13132957\charrsid13132957 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email..EXAMPLE
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript > .\\DHCP_Inventory_V1_4.ps1 -Fo\hich\af2\dbch\af31505\loch\f2 lder \\\\FileServer\\ShareName
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
-\par \hich\af2\dbch\af31505\loch\f2     $env:\hich\af2\dbch\af31505\loch\f2 username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName
-\par \hich\af2\dbch\af31505\loch\f2     DHCPServer01
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Sof\hich\af2\dbch\af31505\loch\f2 tware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DH\hich\af2\dbch\af31505\loch\f2 CP server DHCPServer01.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
-\par \hich\af2\dbch\af31505\loch\f2     to enter val\hich\af2\dbch\af31505\loch\f2 id credentials.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14369692\charrsid14369692 \hich\af2\dbch\af31505\loch\f2     smtp.office365.com -SmtpPort 587 -UseSSL -From Webster\hich\af2\dbch\af31505\loch\f2 @CarlWebster\hich\af2\dbch\af31505\loch\f2 .com -To
-
-\par \hich\af2\dbch\af31505\loch\f2     ITGroup@CarlWebster\hich\af2\dbch\af31505\loch\f2 .com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Folder \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_\hich\af2\dbch\af31505\loch\f2 USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName\hich\af2\dbch\af31505\loch\f2 ="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User N\hich\af2\dbch\af31505\loch\f2 ame.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely ag\hich\af2\dbch\af31505\loch\f2 ainst DHCP server DHCPServer01.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster\hich\af2\dbch\af31505\loch\f2 @carlwebster\hich\af2\dbch\af31505\loch\f2 .com, sending to ITGroup@carlwebster\hich\af2\dbch\af31505\loch\f2 .com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,\hich\af2\dbch\af31505\loch\f2  the user will be prompted
-\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Dev -ScriptInfo -Log
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.\hich\af2\dbch\af31505\loch\f2 tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
+\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/2956491?hl=en
+\par \hich\af2\dbch\af31505\loch\f2     https://support.google.com/a/answer/176600?hl=en
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" opti\hich\af2\dbch\af31505\loch\f2 on on your account.
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for t\hich\af2\dbch\af31505\loch\f2 he User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Co\hich\af2\dbch\af31505\loch\f2 mpany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will \hich\af2\dbch\af31505\loch\f2 use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName DHCPServer01
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -Fr\hich\af2\dbch\af31505\loch\f2 om Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will be run remotely against DHCP server DHCPServer01.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE **\hich\af2\dbch\af31505\loch\f2 *
+\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
+\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     t\hich\af2\dbch\af31505\loch\f2 o enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -Dev -ScriptInfo -Log
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Admini\hich\af2\dbch\af31505\loch\f2 strator for the User Name.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the scr\hich\af2\dbch\af31505\loch\f2 ipt.
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named DHCPInventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
@@ -1147,18 +1230,18 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and add additional information for each server about its
-\par \hich\af2\dbch\af31505\loch\f2     hardw\hich\af2\dbch\af31505\loch\f2 are.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     hardware.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1167,42 +1250,43 @@ terName <String>] [-Folder <String>] [-Hardware] [-IncludeLeases]
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------------------\hich\af2\dbch\af31505\loch\f2  EXAMPLE 19 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -AllDHCPServers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will find all Authorized\hich\af2\dbch\af31505\loch\f2  DHCP servers and will process all servers that are
+\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript will find all Authorized DHCP servers and will process all servers that are
 \par \hich\af2\dbch\af31505\loch\f2     online.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -AllDHCPServers
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\Company="Carl Webster\hich\af2\dbch\af31505\loch\f2 "
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster\hich\af2\dbch\af31505\loch\f2  for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Even though DHCPServer01 is specified, the scrip\hich\af2\dbch\af31505\loch\f2 t will find all Authorized DHCP servers
-\par \hich\af2\dbch\af31505\loch\f2     and will process all servers that are online.
+\par \hich\af2\dbch\af31505\loch\f2     Even though DHCPServer01 is specified, the script will find all Authorized DHCP servers
+\par \hich\af2\dbch\af31505\loch\f2     and will\hich\af2\dbch\af31505\loch\f2  process all servers that are online.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
@@ -1324,8 +1408,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f0d4
-d0bbeab4d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d0af
+13de4d13d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/DHCP_Script_ChangeLog.txt
+++ b/DHCP_Script_ChangeLog.txt
@@ -8,7 +8,7 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
-#Version 1.43
+#Version 1.43 17-Apr-2020
 #	Add parameter IncludeOptions to add DHCP Options to report.
 #		New Function ProcessDHCPOptions
 #		Update Functions ShowScriptOptions and ProcessScriptEnd 
@@ -17,6 +17,7 @@
 #	In the GetIPv4ScopeData functions, ignore Option ID 81
 #		This Option ID is set when Name Protection is disabled in the DNS
 #		tab in a Scope's Properties. Option ID 81 is not in the Predefined Options.
+#		https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
 #	Reorder parameters
 #	Update Function SendEmail to handle anonymous unauthenticated email
 #		Update Help Text with examples

--- a/DHCP_Script_ChangeLog.txt
+++ b/DHCP_Script_ChangeLog.txt
@@ -8,6 +8,26 @@
 #@essentialexch on Twitter
 #https://www.essential.exchange/blog/
 
+#Version 1.43
+#	Add parameter IncludeOptions to add DHCP Options to report.
+#		New Function ProcessDHCPOptions
+#		Update Functions ShowScriptOptions and ProcessScriptEnd 
+#		Update Help Text
+#	Reorder parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#		Update Help Text with examples
+#	Update script to match updates to other documentation scripts
+#		Checking for multiple output formats selected
+#		Change Text output to use [System.Text.StringBuilder]
+#		Function Line
+#		Function SaveandCloseTextDocument
+#		Function WriteWordLine
+#		Function WriteHTMLLine
+#		Function AddHTMLTable
+#		Function FormatHTMLTable
+#		Function FormatHTMLTable
+#		Function CheckHTMLColor
+
 #Version 1.42 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 

--- a/DHCP_Script_ChangeLog.txt
+++ b/DHCP_Script_ChangeLog.txt
@@ -13,6 +13,10 @@
 #		New Function ProcessDHCPOptions
 #		Update Functions ShowScriptOptions and ProcessScriptEnd 
 #		Update Help Text
+#	Cleanup spacing in some of the Write-Verbose statements
+#	In the GetIPv4ScopeData functions, ignore Option ID 81
+#		This Option ID is set when Name Protection is disabled in the DNS
+#		tab in a Scope's Properties. Option ID 81 is not in the Predefined Options.
 #	Reorder parameters
 #	Update Function SendEmail to handle anonymous unauthenticated email
 #		Update Help Text with examples

--- a/dhcp_inventory_V1_4.ps1
+++ b/dhcp_inventory_V1_4.ps1
@@ -382,7 +382,7 @@
 	
 	The script will find all Authorized DHCP servers and will process all servers that are 
 	online.
-	Output will contains DHCP Options information.
+	Output will contain DHCP Options information.
 .EXAMPLE
 	PS C:\PSScript .\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting" 
 	-CoverPage "Mod" -UserName "Carl Webster" -ComputerName DHCPServer01
@@ -611,7 +611,7 @@
 	NAME: DHCP_Inventory_V1_4.ps1
 	VERSION: 1.43
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: April 15, 2020
+	LASTEDIT: April 16, 2020
 #>
 
 #endregion
@@ -752,7 +752,7 @@ Param(
 
 #Version 1.0 released to the community on May 31, 2014
 
-#Version 1.43
+#Version 1.43 17-Apr-2020
 #	Add parameter IncludeOptions to add DHCP Options to report.
 #		New Function ProcessDHCPOptions
 #		Update Functions ShowScriptOptions and ProcessScriptEnd 
@@ -761,6 +761,7 @@ Param(
 #	In the GetIPv4ScopeData functions, ignore Option ID 81
 #		This Option ID is set when Name Protection is disabled in the DNS
 #		tab in a Scope's Properties. Option ID 81 is not in the Predefined Options.
+#		https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
 #	Reorder parameters
 #	Update Function SendEmail to handle anonymous unauthenticated email
 #		Update Help Text with examples
@@ -6160,7 +6161,7 @@ Function ProcessIPv4Properties
 			[int]$xRow = 0
 			ForEach($Failover in $Failovers)
 			{
-				Write-Verbose "$(Get-Date):`t`tProcessing failover $($Failover.Name)"
+				Write-Verbose "$(Get-Date): `t`tProcessing failover $($Failover.Name)"
 				$xRow++
 				$Table.Cell($xRow,1).Range.Text = "Relationship name"
 				$Table.Cell($xRow,2).Range.Text = $Failover.Name
@@ -6283,7 +6284,7 @@ Function ProcessIPv4Properties
 		{
 			ForEach($Failover in $Failovers)
 			{
-				Write-Verbose "$(Get-Date):`t`tProcessing failover $($Failover.Name)"
+				Write-Verbose "$(Get-Date): `t`tProcessing failover $($Failover.Name)"
 				Line 2 "Relationship name: " $Failover.Name
 						
 				Line 2 "State of the server`t: " -NoNewLine
@@ -6376,7 +6377,7 @@ Function ProcessIPv4Properties
 		{
 			ForEach($Failover in $Failovers)
 			{
-				Write-Verbose "$(Get-Date):`t`tProcessing failover $($Failover.Name)"
+				Write-Verbose "$(Get-Date): `t`tProcessing failover $($Failover.Name)"
 				$rowdata = @()
 				$columnHeaders = @("Relationship name",($htmlsilver -bor $htmlbold),$Failover.Name,$htmlwhite)
 						
@@ -6923,7 +6924,7 @@ Function GetIPv4ScopeData
 {
 	Param([object]$IPv4Scope, [int]$xStartLevel)
 	
-	Write-Verbose "$(Get-Date):Build array of Allow/Deny filters"
+	Write-Verbose "$(Get-Date): `tBuild array of Allow/Deny filters"
 	$Filters = Get-DHCPServerV4Filter -ComputerName $Script:DHCPServerName -EA 0
 
 	If($MSWord -or $PDF)
@@ -7323,6 +7324,8 @@ Function GetIPv4ScopeData_WordPDF
 				If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
 				{
 					#ignore these two option IDs
+					https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
+					https://jimswirelessworld.wordpress.com/2019/01/03/you-should-care-about-dhcp-option-51/
 				}
 				Else
 				{
@@ -8000,6 +8003,8 @@ Function GetIPv4ScopeData_HTML
 			If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
 			{
 				#ignore these two option IDs
+				https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
+				https://jimswirelessworld.wordpress.com/2019/01/03/you-should-care-about-dhcp-option-51/
 			}
 			Else
 			{
@@ -8277,7 +8282,7 @@ Function GetIPv4ScopeData_Text
 {
 	Param([int] $xStartLevel, [object]$filters)
 
-	Write-Verbose "$(Get-Date):`tGetting IPv4 scope data for scope $($IPv4Scope.Name)"
+	Write-Verbose "$(Get-Date): `tGetting IPv4 scope data for scope $($IPv4Scope.Name)"
 	Line 0 "Scope [$($IPv4Scope.ScopeId)] $($IPv4Scope.Name)"
 	Line 1 "Address Pool:"
 	Line 2 "Start IP Address`t: " $IPv4Scope.StartRange
@@ -8304,7 +8309,7 @@ Function GetIPv4ScopeData_Text
 
 	If($IncludeLeases)
 	{
-		Write-Verbose "$(Get-Date):`t`tGetting leases"
+		Write-Verbose "$(Get-Date): `t`tGetting leases"
 		
 		Line 1 "Address Leases:"
 		$Leases = Get-DHCPServerV4Lease -ComputerName $Script:DHCPServerName -ScopeId  $IPv4Scope.ScopeId -EA 0 | Sort-Object IPAddress
@@ -8312,7 +8317,7 @@ Function GetIPv4ScopeData_Text
 		{
 			ForEach($Lease in $Leases)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 				If($Null -ne $Lease.LeaseExpiryTime)
 				{
 					$LeaseStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -8417,7 +8422,7 @@ Function GetIPv4ScopeData_Text
 		$Leases = $Null
 	}
 
-	Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+	Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 	Line 1 "Exclusions:"
 	$Exclusions = Get-DHCPServerV4ExclusionRange -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0 | Sort-Object StartRange
 	If($? -and $Null -ne $Exclusions)
@@ -8439,14 +8444,14 @@ Function GetIPv4ScopeData_Text
 	}
 	$Exclusions = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting reservations"
+	Write-Verbose "$(Get-Date): `t`tGetting reservations"
 	Line 1 "Reservations:"
 	$Reservations = Get-DHCPServerV4Reservation -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0 | Sort-Object IPAddress
 	If($? -and $Null -ne $Reservations)
 	{
 		ForEach($Reservation in $Reservations)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing reservation $($Reservation.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing reservation $($Reservation.Name)"
 			Line 2 "Reservation name`t: " $Reservation.Name
 			Line 2 "IP address`t`t: " $Reservation.IPAddress
 			Line 2 "MAC address`t`t: " $Reservation.ClientId
@@ -8456,7 +8461,7 @@ Function GetIPv4ScopeData_Text
 				Line 2 "Description`t`t: " $Reservation.Description
 			}
 
-			Write-Verbose "$(Get-Date):`t`t`t`tGetting DNS settings"
+			Write-Verbose "$(Get-Date): `t`t`t`tGetting DNS settings"
 			$DNSSettings = Get-DHCPServerV4DnsSetting -ComputerName $Script:DHCPServerName -IPAddress $Reservation.IPAddress -EA 0
 			If($? -and $Null -ne $DNSSettings)
 			{
@@ -8480,7 +8485,7 @@ Function GetIPv4ScopeData_Text
 	}
 	$Reservations = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting scope options"
+	Write-Verbose "$(Get-Date): `t`tGetting scope options"
 	Line 1 "Scope Options:"
 	$ScopeOptions = Get-DHCPServerV4OptionValue -All -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0 | Sort-Object OptionId
 
@@ -8508,10 +8513,12 @@ Function GetIPv4ScopeData_Text
 			If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
 			{
 				#ignore these two option IDs
+				https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
+				https://jimswirelessworld.wordpress.com/2019/01/03/you-should-care-about-dhcp-option-51/
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ScopeOption.Name)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ScopeOption.Name)"
 				Line 2 "Option Name`t: $($ScopeOption.OptionId.ToString("00000")) $($ScopeOption.Name)" 
 				Line 2 "Vendor`t`t: " -NoNewLine
 				If([string]::IsNullOrEmpty($ScopeOption.VendorClass))
@@ -8549,7 +8556,7 @@ Function GetIPv4ScopeData_Text
 	}
 	$ScopeOptions = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting policies"
+	Write-Verbose "$(Get-Date): `t`tGetting policies"
 	Line 1 "Policies:"
 	$ScopePolicies = Get-DHCPServerV4Policy -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0 | Sort-Object ProcessingOrder
 
@@ -8557,7 +8564,7 @@ Function GetIPv4ScopeData_Text
 	{
 		ForEach($Policy in $ScopePolicies)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing policy name $($Policy.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing policy name $($Policy.Name)"
 			Line 2 "Policy Name`t`t: " $Policy.Name
 			If(![string]::IsNullOrEmpty($Policy.Description))
 			{
@@ -8598,7 +8605,7 @@ Function GetIPv4ScopeData_Text
 	}
 	$ScopePolicies = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting DNS"
+	Write-Verbose "$(Get-Date): `t`tGetting DNS"
 	Line 1 "DNS:"
 	$DNSSettings = Get-DHCPServerV4DnsSetting -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0
 	If($? -and $Null -ne $DNSSettings)
@@ -8614,7 +8621,7 @@ Function GetIPv4ScopeData_Text
 	#next tab is Network Access Protection but I can't find anything that gives me that info
 	
 	#failover
-	Write-Verbose "$(Get-Date):`t`tGetting Failover"
+	Write-Verbose "$(Get-Date): `t`tGetting Failover"
 	Line 1 "Failover:"
 	
 	$Failovers = Get-DHCPServerV4Failover -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0
@@ -8623,7 +8630,7 @@ Function GetIPv4ScopeData_Text
 	{
 		ForEach($Failover in $Failovers)
 		{
-			Write-Verbose "$(Get-Date):`t`tProcessing failover $($Failover.Name)"
+			Write-Verbose "$(Get-Date): `t`tProcessing failover $($Failover.Name)"
 			Line 2 "Relationship name: " $Failover.Name
 			Line 2 "Partner Server`t`t`t: " $Failover.PartnerServer
 			Line 2 "Mode`t`t`t`t: " $Failover.Mode
@@ -8749,7 +8756,7 @@ Function GetIPv4ScopeData_Text
 	}
 	$Failovers = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting Scope statistics"
+	Write-Verbose "$(Get-Date): `t`tGetting Scope statistics"
 	Line 1 "Statistics:"
 
 	$Statistics = Get-DHCPServerV4ScopeStatistics -ComputerName $Script:DHCPServerName -ScopeId $IPv4Scope.ScopeId -EA 0
@@ -8771,7 +8778,7 @@ Function GetIPv4ScopeData_Text
 
 Function GetIPv6ScopeData_WordPDF
 {
-	Write-Verbose "$(Get-Date):`tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
+	Write-Verbose "$(Get-Date): `tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
 	WriteWordLine 3 0 "Scope [$($IPv6Scope.Prefix)] $($IPv6Scope.Name)"
 	WriteWordLine 4 0 "General"
 	$TableRange = $doc.Application.Selection.Range
@@ -8815,7 +8822,7 @@ Function GetIPv6ScopeData_WordPDF
 	$TableRange = $Null
 	$Table = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting scope DNS settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope DNS settings"
 	WriteWordLine 4 0 "DNS"
 	$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
 	If($? -and $Null -ne $DNSSettings)
@@ -8828,7 +8835,7 @@ Function GetIPv6ScopeData_WordPDF
 	}
 	$DNSSettings = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting scope lease settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope lease settings"
 	WriteWordLine 4 0 "Lease"
 	
 	$PrefStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -8865,7 +8872,7 @@ Function GetIPv6ScopeData_WordPDF
 	
 	If($IncludeLeases)
 	{
-		Write-Verbose "$(Get-Date):`t`tGetting leases"
+		Write-Verbose "$(Get-Date): `t`tGetting leases"
 		WriteWordLine 4 0 "Address Leases"
 		$Leases = Get-DHCPServerV6Lease -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 		If($? -and $Null -ne $Leases)
@@ -8888,7 +8895,7 @@ Function GetIPv6ScopeData_WordPDF
 			[int]$xRow = 0
 			ForEach($Lease in $Leases)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 				$xRow++
 				If($Null -ne $Lease.LeaseExpiryTime)
 				{
@@ -8954,7 +8961,7 @@ Function GetIPv6ScopeData_WordPDF
 		$Leases = $Null
 	}
 
-	Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+	Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 	WriteWordLine 4 0 "Exclusions"
 	$Exclusions = Get-DHCPServerV6ExclusionRange -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object StartRange
 	If($? -and $Null -ne $Exclusions)
@@ -9008,14 +9015,14 @@ Function GetIPv6ScopeData_WordPDF
 	}
 	$Exclusions = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting reservations"
+	Write-Verbose "$(Get-Date): `t`tGetting reservations"
 	WriteWordLine 4 0 "Reservations"
 	$Reservations = Get-DHCPServerV6Reservation -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 	If($? -and $Null -ne $Reservations)
 	{
 		ForEach($Reservation in $Reservations)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing reservation $($Reservation.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing reservation $($Reservation.Name)"
 			$TableRange = $doc.Application.Selection.Range
 			[int]$Columns = 2
 			If([string]::IsNullOrEmpty($Reservation.Description))
@@ -9055,7 +9062,7 @@ Function GetIPv6ScopeData_WordPDF
 			$TableRange = $Null
 			$Table = $Null
 
-			Write-Verbose "$(Get-Date):`t`t`t`tGetting DNS settings"
+			Write-Verbose "$(Get-Date): `t`t`t`tGetting DNS settings"
 			$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -IPAddress $Reservation.IPAddress -EA 0
 			If($? -and $Null -ne $DNSSettings)
 			{
@@ -9102,7 +9109,7 @@ Function GetIPv6ScopeData_WordPDF
 		[int]$xRow = 0
 		ForEach($ScopeOption in $ScopeOptions)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ScopeOption.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ScopeOption.Name)"
 			$xRow++
 			$Table.Cell($xRow,1).Range.Text = "Option Name"
 			$Table.Cell($xRow,2).Range.Text = "$($ScopeOption.OptionId.ToString("00000")) $($ScopeOption.Name)" 
@@ -9146,7 +9153,7 @@ Function GetIPv6ScopeData_WordPDF
 	}
 	$ScopeOptions = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting Scope statistics"
+	Write-Verbose "$(Get-Date): `t`tGetting Scope statistics"
 	WriteWordLine 4 0 "Statistics"
 
 	$Statistics = Get-DHCPServerV6ScopeStatistics -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
@@ -9168,7 +9175,7 @@ Function GetIPv6ScopeData_WordPDF
 
 Function GetIPv6ScopeData_HTML
 {
-	Write-Verbose "$(Get-Date):`tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
+	Write-Verbose "$(Get-Date): `tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
 	WriteHTMLLine 3 0 "Scope [$($IPv6Scope.Prefix)] $($IPv6Scope.Name)"
 	WriteHTMLLine 4 0 "General"
 	$rowdata = @()
@@ -9187,7 +9194,7 @@ Function GetIPv6ScopeData_HTML
 	FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "300"
 	InsertBlankLine
 
-	Write-Verbose "$(Get-Date):`t`tGetting scope DNS settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope DNS settings"
 	WriteHTMLLine 4 0 "DNS"
 	$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
 	If($? -and $Null -ne $DNSSettings)
@@ -9200,7 +9207,7 @@ Function GetIPv6ScopeData_HTML
 	}
 	$DNSSettings = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting scope lease settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope lease settings"
 	WriteHTMLLine 4 0 "Lease"
 	
 	$PrefStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -9223,14 +9230,14 @@ Function GetIPv6ScopeData_HTML
 	
 	If($IncludeLeases)
 	{
-		Write-Verbose "$(Get-Date):`t`tGetting leases"
+		Write-Verbose "$(Get-Date): `t`tGetting leases"
 		WriteHTMLLine 4 0 "Address Leases"
 		$Leases = Get-DHCPServerV6Lease -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 		If($? -and $Null -ne $Leases)
 		{
 			ForEach($Lease in $Leases)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 				If($Null -ne $Lease.LeaseExpiryTime)
 				{
 					$LeaseStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -9269,7 +9276,7 @@ Function GetIPv6ScopeData_HTML
 		$Leases = $Null
 	}
 
-	Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+	Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 	WriteHTMLLine 4 0 "Exclusions"
 	$Exclusions = Get-DHCPServerV6ExclusionRange -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object StartRange
 	If($? -and $Null -ne $Exclusions)
@@ -9296,14 +9303,14 @@ Function GetIPv6ScopeData_HTML
 	}
 	$Exclusions = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting reservations"
+	Write-Verbose "$(Get-Date): `t`tGetting reservations"
 	WriteHTMLLine 4 0 "Reservations"
 	$Reservations = Get-DHCPServerV6Reservation -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 	If($? -and $Null -ne $Reservations)
 	{
 		ForEach($Reservation in $Reservations)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing reservation $($Reservation.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing reservation $($Reservation.Name)"
 			$rowdata = @()
 			$columnHeaders = @("Reservation name",($htmlsilver -bor $htmlbold),$Reservation.Name,$htmlwhite)
 			$rowdata += @(,('IPv6 address',($htmlsilver -bor $htmlbold),$Reservation.IPAddress.ToString(),$htmlwhite))
@@ -9318,7 +9325,7 @@ Function GetIPv6ScopeData_HTML
 			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "300"
 			InsertBlankLine
 
-			Write-Verbose "$(Get-Date):`t`t`t`tGetting DNS settings"
+			Write-Verbose "$(Get-Date): `t`t`t`tGetting DNS settings"
 			$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -IPAddress $Reservation.IPAddress -EA 0
 			If($? -and $Null -ne $DNSSettings)
 			{
@@ -9349,7 +9356,7 @@ Function GetIPv6ScopeData_HTML
 	{
 		ForEach($ScopeOption in $ScopeOptions)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ScopeOption.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ScopeOption.Name)"
 			$rowdata = @()
 			$columnHeaders = @("Option Name",($htmlsilver -bor $htmlbold),"$($ScopeOption.OptionId.ToString("00000")) $($ScopeOption.Name)",$htmlwhite)
 			
@@ -9381,7 +9388,7 @@ Function GetIPv6ScopeData_HTML
 	}
 	$ScopeOptions = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting Scope statistics"
+	Write-Verbose "$(Get-Date): `t`tGetting Scope statistics"
 	WriteHTMLLine 4 0 "Statistics"
 
 	$Statistics = Get-DHCPServerV6ScopeStatistics -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
@@ -9403,7 +9410,7 @@ Function GetIPv6ScopeData_HTML
 
 Function GetIPv6ScopeData_Text
 {
-	Write-Verbose "$(Get-Date):`tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
+	Write-Verbose "$(Get-Date): `tGetting IPv6 scope data for scope $($IPv6Scope.Name)"
 	Line 0 "Scope [$($IPv6Scope.Prefix)] $($IPv6Scope.Name)"
 	Line 1 "General"
 	Line 2 "Prefix`t`t: " $IPv6Scope.Prefix
@@ -9416,7 +9423,7 @@ Function GetIPv6ScopeData_Text
 		Line 2 "Description`t: " $IPv6Scope.Description
 	}
 
-	Write-Verbose "$(Get-Date):`t`tGetting scope DNS settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope DNS settings"
 	Line 1 "DNS"
 	$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
 	If($? -and $Null -ne $DNSSettings)
@@ -9429,7 +9436,7 @@ Function GetIPv6ScopeData_Text
 	}
 	$DNSSettings = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting scope lease settings"
+	Write-Verbose "$(Get-Date): `t`tGetting scope lease settings"
 	Line 1 "Lease"
 	
 	$PrefStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -9446,14 +9453,14 @@ Function GetIPv6ScopeData_Text
 
 	If($IncludeLeases)
 	{
-		Write-Verbose "$(Get-Date):`t`tGetting leases"
+		Write-Verbose "$(Get-Date): `t`tGetting leases"
 		Line 1 "Address Leases:"
 		$Leases = Get-DHCPServerV6Lease -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 		If($? -and $Null -ne $Leases)
 		{
 			ForEach($Lease in $Leases)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 				If($Null -ne $Lease.LeaseExpiryTime)
 				{
 					$LeaseStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -9492,7 +9499,7 @@ Function GetIPv6ScopeData_Text
 		$Leases = $Null
 	}
 
-	Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+	Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 	Line 1 "Exclusions:"
 	$Exclusions = Get-DHCPServerV6ExclusionRange -ComputerName $Script:DHCPServerName -Prefix  $IPv6Scope.Prefix -EA 0 | Sort-Object StartRange
 	If($? -and $Null -ne $Exclusions)
@@ -9514,14 +9521,14 @@ Function GetIPv6ScopeData_Text
 	}
 	$Exclusions = $Null
 
-	Write-Verbose "$(Get-Date):`t`tGetting reservations"
+	Write-Verbose "$(Get-Date): `t`tGetting reservations"
 	Line 1 "Reservations:"
 	$Reservations = Get-DHCPServerV6Reservation -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object IPAddress
 	If($? -and $Null -ne $Reservations)
 	{
 		ForEach($Reservation in $Reservations)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing reservation $($Reservation.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing reservation $($Reservation.Name)"
 			Line 2 "Reservation name: " $Reservation.Name
 			Line 2 "IPv6 address: " $Reservation.IPAddress
 			Line 2 "DUID`t`t: " $Reservation.ClientDuid
@@ -9531,7 +9538,7 @@ Function GetIPv6ScopeData_Text
 				Line 2 "Description`t: " $Reservation.Description
 			}
 
-			Write-Verbose "$(Get-Date):`t`t`t`tGetting DNS settings"
+			Write-Verbose "$(Get-Date): `t`t`t`tGetting DNS settings"
 			$DNSSettings = Get-DHCPServerV6DnsSetting -ComputerName $Script:DHCPServerName -IPAddress $Reservation.IPAddress -EA 0
 			If($? -and $Null -ne $DNSSettings)
 			{
@@ -9562,7 +9569,7 @@ Function GetIPv6ScopeData_Text
 	{
 		ForEach($ScopeOption in $ScopeOptions)
 		{
-			Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ScopeOption.Name)"
+			Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ScopeOption.Name)"
 			Line 2 "Option Name`t: $($ScopeOption.OptionId.ToString("00000")) $($ScopeOption.Name)" 
 			Line 2 "Vendor`t`t: " -NoNewLine
 			If([string]::IsNullOrEmpty($ScopeOption.VendorClass))
@@ -9589,7 +9596,7 @@ Function GetIPv6ScopeData_Text
 	}
 	$ScopeOptions = $Null
 	
-	Write-Verbose "$(Get-Date):`t`tGetting Scope statistics"
+	Write-Verbose "$(Get-Date): `t`tGetting Scope statistics"
 	Line 1 "Statistics:"
 
 	$Statistics = Get-DHCPServerV6ScopeStatistics -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0
@@ -9990,7 +9997,7 @@ Function ProcessIPv4MulticastScopes
 						WriteWordLine 0 0 "Multicast scope expires on $($IPv4MulticastScope.ExpiryTime)"
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+					Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 					WriteWordLine 4 0 "Exclusions"
 					$Exclusions = Get-DHCPServerV4MulticastExclusionRange -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
 					If($? -and $Null -ne $Exclusions)
@@ -10046,7 +10053,7 @@ Function ProcessIPv4MulticastScopes
 					#leases
 					If($IncludeLeases)
 					{
-						Write-Verbose "$(Get-Date):`t`tGetting leases"
+						Write-Verbose "$(Get-Date): `t`tGetting leases"
 						
 						WriteWordLine 4 0 "Address Leases"
 						$Leases = Get-DHCPServerV4MulticastLease -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0 | Sort-Object IPAddress
@@ -10071,7 +10078,7 @@ Function ProcessIPv4MulticastScopes
 							[int]$xRow = 0
 							ForEach($Lease in $Leases)
 							{
-								Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+								Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 								If($Null -ne $Lease.LeaseExpiryTime)
 								{
 									$LeaseEndStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -10159,7 +10166,7 @@ Function ProcessIPv4MulticastScopes
 						$Leases = $Null
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting Multicast Scope statistics"
+					Write-Verbose "$(Get-Date): `t`tGetting Multicast Scope statistics"
 					WriteWordLine 4 0 "Statistics"
 
 					$Statistics = Get-DHCPServerV4MulticastScopeStatistics -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
@@ -10204,7 +10211,7 @@ Function ProcessIPv4MulticastScopes
 						Line 0 "Multicast scope expires on $($IPv4MulticastScope.ExpiryTime)"
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+					Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 					Line 1 "Exclusions:"
 					$Exclusions = Get-DHCPServerV4MulticastExclusionRange -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
 					If($? -and $Null -ne $Exclusions)
@@ -10228,7 +10235,7 @@ Function ProcessIPv4MulticastScopes
 					#leases
 					If($IncludeLeases)
 					{
-						Write-Verbose "$(Get-Date):`t`tGetting leases"
+						Write-Verbose "$(Get-Date): `t`tGetting leases"
 						
 						Line 1 "Address Leases:"
 						$Leases = Get-DHCPServerV4MulticastLease -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0 | Sort-Object IPAddress
@@ -10236,7 +10243,7 @@ Function ProcessIPv4MulticastScopes
 						{
 							ForEach($Lease in $Leases)
 							{
-								Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+								Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 								If($Null -ne $Lease.LeaseExpiryTime)
 								{
 									$LeaseEndStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -10301,7 +10308,7 @@ Function ProcessIPv4MulticastScopes
 						$Leases = $Null
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting Multicast Scope statistics"
+					Write-Verbose "$(Get-Date): `t`tGetting Multicast Scope statistics"
 					Line 1 "Statistics:"
 
 					$Statistics = Get-DHCPServerV4MulticastScopeStatistics -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
@@ -10349,7 +10356,7 @@ Function ProcessIPv4MulticastScopes
 						WriteHTMLLine 0 1 "Multicast scope lifetime: Multicast scope expires on $($IPv4MulticastScope.ExpiryTime)"
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting exclusions"
+					Write-Verbose "$(Get-Date): `t`tGetting exclusions"
 					WriteHTMLLine 4 0 "Exclusions"
 					$Exclusions = Get-DHCPServerV4MulticastExclusionRange -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
 					If($? -and $Null -ne $Exclusions)
@@ -10378,7 +10385,7 @@ Function ProcessIPv4MulticastScopes
 					#leases
 					If($IncludeLeases)
 					{
-						Write-Verbose "$(Get-Date):`t`tGetting leases"
+						Write-Verbose "$(Get-Date): `t`tGetting leases"
 						
 						WriteHTMLLine 4 0 "Address Leases"
 						$Leases = Get-DHCPServerV4MulticastLease -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0 | Sort-Object IPAddress
@@ -10386,7 +10393,7 @@ Function ProcessIPv4MulticastScopes
 						{
 							ForEach($Lease in $Leases)
 							{
-								Write-Verbose "$(Get-Date):`t`t`tProcessing lease $($Lease.IPAddress)"
+								Write-Verbose "$(Get-Date): `t`t`tProcessing lease $($Lease.IPAddress)"
 								If($Null -ne $Lease.LeaseExpiryTime)
 								{
 									$LeaseEndStr = [string]::format("{0} days, {1} hours, {2} minutes", `
@@ -10457,7 +10464,7 @@ Function ProcessIPv4MulticastScopes
 						$Leases = $Null
 					}
 					
-					Write-Verbose "$(Get-Date):`t`tGetting Multicast Scope statistics"
+					Write-Verbose "$(Get-Date): `t`tGetting Multicast Scope statistics"
 					WriteHTMLLine 4 0 "Statistics"
 
 					$Statistics = Get-DHCPServerV4MulticastScopeStatistics -ComputerName $Script:DHCPServerName -Name $IPv4MulticastScope.Name -EA 0
@@ -10645,7 +10652,7 @@ Function ProcessServerOptions
 			[int]$xRow = 0
 			ForEach($ServerOption in $ServerOptions)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ServerOption.Name)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ServerOption.Name)"
 				$xRow++
 				$Table.Cell($xRow,1).Range.Text = "Option Name"
 				$Table.Cell($xRow,2).Range.Text = "$($ServerOption.OptionId.ToString("000")) $($ServerOption.Name)"
@@ -10693,7 +10700,7 @@ Function ProcessServerOptions
 		{
 			ForEach($ServerOption in $ServerOptions)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ServerOption.Name)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ServerOption.Name)"
 				Line 2 "Option Name`t: $($ServerOption.OptionId.ToString("000")) $($ServerOption.Name)"
 				Line 2 "Vendor`t`t: " -NoNewLine
 				If([string]::IsNullOrEmpty($ServerOption.VendorClass))
@@ -10723,7 +10730,7 @@ Function ProcessServerOptions
 		{
 			ForEach($ServerOption in $ServerOptions)
 			{
-				Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ServerOption.Name)"
+				Write-Verbose "$(Get-Date): `t`t`tProcessing option name $($ServerOption.Name)"
 				$rowdata = @()
 				$columnHeaders = @("Option Name",($htmlsilver -bor $htmlbold),"$($ServerOption.OptionId.ToString("000")) $($ServerOption.Name)",$htmlwhite)
 				
@@ -10975,7 +10982,7 @@ Function ProcessIPv4Filters
 		WriteHTMLLine 3 0 "Filters"
 	}
 
-	Write-Verbose "$(Get-Date):`tAllow filters"
+	Write-Verbose "$(Get-Date): `tAllow filters"
 	$AllowFilters = Get-DHCPServerV4Filter -List Allow -ComputerName $Script:DHCPServerName -EA 0 | Sort-Object MacAddress
 
 	If($? -and $Null -ne $AllowFilters)
@@ -11080,7 +11087,7 @@ Function ProcessIPv4Filters
 	$AllowFilters = $Null
 	[gc]::collect() 
 
-	Write-Verbose "$(Get-Date):`tDeny filters"
+	Write-Verbose "$(Get-Date): `tDeny filters"
 	$DenyFilters = Get-DHCPServerV4Filter -List Deny -ComputerName $Script:DHCPServerName -EA 0 | Sort-Object MacAddress
 	If($? -and $Null -ne $DenyFilters)
 	{
@@ -11863,20 +11870,20 @@ Function ProcessDHCPOptions
 					$Item.Description, 
 					$Item.Type, 
 					$Item.VendorClass, 
-					$( If( $null –ne $Item.DefaultValue ) { $Item.DefaultValue –join ';' } Else { ' ' } ), 
+					$( If( $null -ne $Item.DefaultValue ) { $Item.DefaultValue -join ';' } Else { ' ' } ), 
 					$Item.MultiValued.ToString() 
 				)
 			}
 			ElseIf($HTML)
 			{
-				$tmpDV = $Item.DefaultValue.SyncRoot
+				#$tmpDV = $Item.DefaultValue.SyncRoot
 				$rowdata += @(,(
 					$Item.OptionId,$htmlwhite,
 					$Item.Name,$htmlwhite,
 					$Item.Description,$htmlwhite,
 					$Item.Type,$htmlwhite,
 					$Item.VendorClass,$htmlwhite,
-					$tmpDV,$htmlwhite,
+					$Item.DefaultValue.SyncRoot,$htmlwhite,
 					$Item.MultiValued.ToString(),$htmlwhite
 				))
 			}

--- a/dhcp_inventory_V1_4.ps1
+++ b/dhcp_inventory_V1_4.ps1
@@ -380,7 +380,8 @@
 	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -AllDHCPServer -HTML -IncludeOptions
 	
 	
-	The script will find all Authorized DHCP servers and will process all servers that are online.
+	The script will find all Authorized DHCP servers and will process all servers that are 
+	online.
 	Output will contains DHCP Options information.
 .EXAMPLE
 	PS C:\PSScript .\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting" 
@@ -421,7 +422,8 @@
 .EXAMPLE
 	PS C:\PSScript .\DHCP_Inventory_V1_4.ps1 -CompanyName "Sherlock Holmes 
 	Consulting"
-	-CoverPage Facet -UserName "Dr. Watson"
+	-CoverPage Facet 
+	-UserName "Dr. Watson"
 	-CompanyEmail SuperSleuth@SherlockHolmes.com
 
 	Will use:
@@ -755,6 +757,10 @@ Param(
 #		New Function ProcessDHCPOptions
 #		Update Functions ShowScriptOptions and ProcessScriptEnd 
 #		Update Help Text
+#	Cleanup spacing in some of the Write-Verbose statements
+#	In the GetIPv4ScopeData functions, ignore Option ID 81
+#		This Option ID is set when Name Protection is disabled in the DNS
+#		tab in a Scope's Properties. Option ID 81 is not in the Predefined Options.
 #	Reorder parameters
 #	Update Function SendEmail to handle anonymous unauthenticated email
 #		Update Help Text with examples
@@ -7314,7 +7320,11 @@ Function GetIPv4ScopeData_WordPDF
 			[int]$xRow = 0
 			ForEach($ScopeOption in $ScopeOptions)
 			{
-				If($ScopeOption.OptionId -ne 51)
+				If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
+				{
+					#ignore these two option IDs
+				}
+				Else
 				{
 					Write-Verbose "$(Get-Date):	`t`t`tProcessing option name $($ScopeOption.Name)"
 					$xRow++
@@ -7987,7 +7997,11 @@ Function GetIPv4ScopeData_HTML
 		
 		ForEach($ScopeOption in $ScopeOptions)
 		{
-			If($ScopeOption.OptionId -ne 51)
+			If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
+			{
+				#ignore these two option IDs
+			}
+			Else
 			{
 				Write-Verbose "$(Get-Date):	`t`t`tProcessing option name $($ScopeOption.Name)"
 				$rowdata = @()
@@ -8491,7 +8505,11 @@ Function GetIPv4ScopeData_Text
 
 		ForEach($ScopeOption in $ScopeOptions)
 		{
-			If($ScopeOption.OptionId -ne 51)
+			If($ScopeOption.OptionId -eq 51 -or $ScopeOption.OptionId -eq 81)
+			{
+				#ignore these two option IDs
+			}
+			Else
 			{
 				Write-Verbose "$(Get-Date):`t`t`tProcessing option name $($ScopeOption.Name)"
 				Line 2 "Option Name`t: $($ScopeOption.OptionId.ToString("00000")) $($ScopeOption.Name)" 
@@ -9060,7 +9078,7 @@ Function GetIPv6ScopeData_WordPDF
 	}
 	$Reservations = $Null
 
-	Write-Verbose "$(Get-Date):Getting IPv6 scope options"
+	Write-Verbose "$(Get-Date): Getting IPv6 scope options"
 	WriteWordLine 4 0 "Scope Options"
 	$ScopeOptions = Get-DHCPServerV6OptionValue -All -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object OptionId
 
@@ -9323,7 +9341,7 @@ Function GetIPv6ScopeData_HTML
 	}
 	$Reservations = $Null
 
-	Write-Verbose "$(Get-Date):Getting IPv6 scope options"
+	Write-Verbose "$(Get-Date): Getting IPv6 scope options"
 	WriteHTMLLine 4 0 "Scope Options"
 	$ScopeOptions = Get-DHCPServerV6OptionValue -All -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object OptionId
 
@@ -9536,7 +9554,7 @@ Function GetIPv6ScopeData_Text
 	}
 	$Reservations = $Null
 
-	Write-Verbose "$(Get-Date):Getting IPv6 scope options"
+	Write-Verbose "$(Get-Date): Getting IPv6 scope options"
 	Line 1 "Scope Options:"
 	$ScopeOptions = Get-DHCPServerV6OptionValue -All -ComputerName $Script:DHCPServerName -Prefix $IPv6Scope.Prefix -EA 0 | Sort-Object OptionId
 
@@ -10587,7 +10605,7 @@ Function ProcessIPv4BOOTPTable
 Function ProcessServerOptions
 {
 	#Server Options
-	Write-Verbose "$(Get-Date):Getting IPv4 server options"
+	Write-Verbose "$(Get-Date): Getting IPv4 server options"
 
 	If($MSWord -or $PDF)
 	{
@@ -10776,7 +10794,7 @@ Function ProcessServerOptions
 Function ProcessPolicies
 {
 	#Policies
-	Write-Verbose "$(Get-Date):Getting IPv4 policies"
+	Write-Verbose "$(Get-Date): Getting IPv4 policies"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 "Policies"
@@ -10943,7 +10961,7 @@ Function ProcessPolicies
 Function ProcessIPv4Filters
 {
 	#Filters
-	Write-Verbose "$(Get-Date):Getting IPv4 filters"
+	Write-Verbose "$(Get-Date): Getting IPv4 filters"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 "Filters"
@@ -11329,7 +11347,7 @@ Function ProcessIPv6Properties
 		}
 		$Statistics = $Null
 
-		Write-Verbose "$(Get-Date):Getting IPv6 scopes"
+		Write-Verbose "$(Get-Date): Getting IPv6 scopes"
 		$IPv6Scopes = Get-DHCPServerV6Scope -ComputerName $Script:DHCPServerName -EA 0
 
 		If($? -and $Null -ne $IPv6Scopes)
@@ -11350,7 +11368,7 @@ Function ProcessIPv6Properties
 		}
 		$IPv6Scopes = $Null
 
-		Write-Verbose "$(Get-Date):Getting IPv6 server options"
+		Write-Verbose "$(Get-Date): Getting IPv6 server options"
 		$selection.InsertNewPage()
 		WriteWordLine 3 0 "Server Options"
 
@@ -11553,7 +11571,7 @@ Function ProcessIPv6Properties
 		
 		$Statistics = $Null
 
-		Write-Verbose "$(Get-Date):Getting IPv6 scopes"
+		Write-Verbose "$(Get-Date): Getting IPv6 scopes"
 		$IPv6Scopes = Get-DHCPServerV6Scope -ComputerName $Script:DHCPServerName -EA 0
 
 		If($? -and $Null -ne $IPv6Scopes)
@@ -11729,7 +11747,7 @@ Function ProcessIPv6Properties
 		}
 		$Statistics = $Null
 
-		Write-Verbose "$(Get-Date):Getting IPv6 scopes"
+		Write-Verbose "$(Get-Date): Getting IPv6 scopes"
 		$IPv6Scopes = Get-DHCPServerV6Scope -ComputerName $Script:DHCPServerName -EA 0
 
 		If($? -and $Null -ne $IPv6Scopes)
@@ -11750,7 +11768,7 @@ Function ProcessIPv6Properties
 		}
 		$IPv6Scopes = $Null
 
-		Write-Verbose "$(Get-Date):Getting IPv6 server options"
+		Write-Verbose "$(Get-Date): Getting IPv6 server options"
 		WriteHTMLLine 3 0 "Server Options"
 
 		$ServerOptions = Get-DHCPServerV6OptionValue -All -ComputerName $Script:DHCPServerName -EA 0 | Sort-Object OptionId
@@ -11794,7 +11812,7 @@ Function ProcessIPv6Properties
 
 Function ProcessDHCPOptions
 {
-	Write-Verbose "$(Get-Date):Getting DHCP Options"
+	Write-Verbose "$(Get-Date): Getting DHCP Options"
 	
 	$DHCPOptions = Get-DhcpServerV4OptionDefinition -ComputerName $Script:DHCPServerName -EA 0
 	

--- a/dhcp_inventory_V1_4.ps1
+++ b/dhcp_inventory_V1_4.ps1
@@ -72,12 +72,6 @@
 		Spanish
 		Swedish
 		
-.PARAMETER AddDateTime
-	Adds a date time stamp to the end of the file name.
-	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2020 at 6PM is 2020-06-01_1800.
-	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
-	This parameter is disabled by default.
 .PARAMETER HTML
 	Creates an HTML file with an .html extension.
 	This parameter is disabled by default.
@@ -92,6 +86,12 @@
 	This parameter uses the Word SaveAs PDF capability.
 .PARAMETER Text
 	Creates a formatted text file with a .txt extension.
+	This parameter is disabled by default.
+.PARAMETER AddDateTime
+	Adds a date time stamp to the end of the file name.
+	Time stamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf or .txt).
 	This parameter is disabled by default.
 .PARAMETER AllDHCPServers
 	The script will process all Authorized DHCP servers that are online.
@@ -197,11 +197,6 @@
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER UserName
-	Username to use for the Cover Page and Footer.
-	The default value is contained in $env:username
-	This parameter has an alias of UN.
-	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER ComputerName
 	DHCP server to run the script against.
 	The computername is used for the report title.
@@ -211,6 +206,14 @@
 	computer name.
 	
 	If both ComputerName and AllDHCPServers are used, AllDHCPServers is used.
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	Text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
 .PARAMETER Folder
 	Specifies the optional output folder to save the output report. 
 .PARAMETER Hardware
@@ -229,6 +232,17 @@
 .PARAMETER IncludeLeases
 	Include DHCP lease information.
 	Default is to not included lease information.
+.PARAMETER IncludeOptions
+	Include DHCP Options information.
+	Default is to not included Options information.
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	Text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
 .PARAMETER SmtpServer
 	Specifies the optional email server to send the output report. 
 .PARAMETER SmtpPort
@@ -243,22 +257,11 @@
 .PARAMETER To
 	Specifies the username for the To email address.
 	If SmtpServer is used, this is a required parameter.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	Text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	Text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
+.PARAMETER UserName
+	Username to use for the Cover Page and Footer.
+	The default value is contained in $env:username
+	This parameter has an alias of UN.
+	This parameter is only valid with the MSWORD and PDF output parameters.
 .EXAMPLE
 	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01
 	
@@ -374,6 +377,12 @@
 	Script will be run remotely against DHCP server DHCPServer03.
 	Output will contain DHCP lease information.
 .EXAMPLE
+	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -AllDHCPServer -HTML -IncludeOptions
+	
+	
+	The script will find all Authorized DHCP servers and will process all servers that are online.
+	Output will contains DHCP Options information.
+.EXAMPLE
 	PS C:\PSScript .\DHCP_Inventory_V1_4.ps1 -CompanyName "Carl Webster Consulting" 
 	-CoverPage "Mod" -UserName "Carl Webster" -ComputerName DHCPServer01
 
@@ -419,7 +428,8 @@
 		Sherlock Holmes Consulting for the Company Name.
 		Facet for the Cover Page format.
 		Dr. Watson for the User Name.
-		SuperSleuth@SherlockHolmes.com for the Company Email..EXAMPLE
+		SuperSleuth@SherlockHolmes.com for the Company Email.
+.EXAMPLE
 	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -Folder \\FileServer\ShareName
 	
 	Will use all default values.
@@ -434,9 +444,48 @@
 	
 	Output file will be saved in the path \\FileServer\ShareName
 .EXAMPLE
-	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -SmtpServer 
-	mail.domain.tld -From XDAdmin@domain.tld -To ITGroup@domain.tld -ComputerName 
-	DHCPServer01
+	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 
+	-SmtpServer mailrelay.domain.tld
+	-From Anonymous@domain.tld 
+	-To ITGroup@domain.tld	
+
+	***SENDING UNAUTHENTICATED EMAIL***
+
+	The script will use the email server mailrelay.domain.tld, sending from 
+	anonymous@domain.tld, sending to ITGroup@domain.tld.
+
+	To send unauthenticated email using an email relay server requires the From email account 
+	to use the name Anonymous.
+
+	The script will use the default SMTP port 25 and will not use SSL.
+	
+	***GMAIL/G SUITE SMTP RELAY***
+	https://support.google.com/a/answer/2956491?hl=en
+	https://support.google.com/a/answer/176600?hl=en
+
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	***GMAIL/G SUITE SMTP RELAY***
+
+	The script will generate an anonymous secure password for the anonymous@domain.tld 
+	account.
+
+	Will use all Default values.
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
+	Webster" or
+	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\Company="Carl Webster"
+	$env:username = Administrator
+
+	Carl Webster for the Company Name.
+	Sideline for the Cover Page format.
+	Administrator for the User Name.
+.EXAMPLE
+	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 
+	-ComputerName DHCPServer01 
+	-SmtpServer mail.domain.tld 
+	-From XDAdmin@domain.tld 
+	-To ITGroup@domain.tld 
+	-ComputerName DHCPServer01
 	
 	Will use all Default values.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
@@ -455,9 +504,13 @@
 	If the current user's credentials are not valid to send email, the user will be prompted 
 	to enter valid credentials.
 .EXAMPLE
-	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 -ComputerName DHCPServer01 -SmtpServer 
-	smtp.office365.com -SmtpPort 587 -UseSSL -From Webster@CarlWebster.com -To 
-	ITGroup@CarlWebster.com
+	PS C:\PSScript > .\DHCP_Inventory_V1_4.ps1 
+	-ComputerName DHCPServer01 
+	-SmtpServer smtp.office365.com 
+	-SmtpPort 587 
+	-UseSSL 
+	-From Webster@CarlWebster.com 
+	-To ITGroup@CarlWebster.com
 	
 	Will use all Default values.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
@@ -471,8 +524,14 @@
 	
 	Script will be run remotely against DHCP server DHCPServer01.
 	
+	*** NOTE ***
+	To send email using a Gmail or g-suite account, you may have to turn ON
+	the "Less secure app access" option on your account.
+	*** NOTE ***
+	
 	Script will use the email server smtp.office365.com on port 587 using SSL, sending from 
 	webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+
 	If the current user's credentials are not valid to send email, the user will be prompted 
 	to enter valid credentials.
 .EXAMPLE
@@ -548,9 +607,9 @@
 	formatted text document.
 .NOTES
 	NAME: DHCP_Inventory_V1_4.ps1
-	VERSION: 1.42
+	VERSION: 1.43
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: December 17, 2019
+	LASTEDIT: April 15, 2020
 #>
 
 #endregion
@@ -561,9 +620,6 @@
 [CmdletBinding(SupportsShouldProcess = $False, ConfirmImpact = "None", DefaultParameterSetName = "Word") ]
 
 Param(
-	[parameter(Mandatory=$False)] 
-	[Switch]$AddDateTime=$False,
-	
 	[parameter(ParameterSetName="HTML",Mandatory=$False)] 
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$HTML=$False,
@@ -580,6 +636,9 @@ Param(
 	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
 	[Switch]$Text=$False,
 
+	[parameter(Mandatory=$False)] 
+	[Switch]$AddDateTime=$False,
+	
 	[parameter(Mandatory=$False)] 
 	[Alias("ALL")]
 	[Switch]$AllDHCPServers=$False,
@@ -626,15 +685,11 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
-	[parameter(ParameterSetName="Word",Mandatory=$False)] 
-	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
-	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
-	[Alias("UN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$UserName=$env:username,
-
 	[parameter(Mandatory=$False)] 
 	[string]$ComputerName="LocalHost",
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Dev=$False,
 	
 	[parameter(Mandatory=$False)] 
 	[string]$Folder="",
@@ -645,6 +700,23 @@ Param(
 
 	[parameter(Mandatory=$False)] 
 	[Switch]$IncludeLeases=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$IncludeOptions=$False,
+
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
+	
+	[parameter(ParameterSetName="Word",Mandatory=$False)] 
+	[parameter(ParameterSetName="PDF",Mandatory=$False)] 
+	[parameter(ParameterSetName="SMTP",Mandatory=$False)] 
+	[Alias("UN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$UserName=$env:username,
 
 	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
 	[string]$SmtpServer="",
@@ -659,18 +731,8 @@ Param(
 	[string]$From="",
 
 	[parameter(ParameterSetName="SMTP",Mandatory=$True)] 
-	[string]$To="",
+	[string]$To=""
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False
-	
 	)
 #endregion
 
@@ -688,6 +750,26 @@ Param(
 
 #Version 1.0 released to the community on May 31, 2014
 
+#Version 1.43
+#	Add parameter IncludeOptions to add DHCP Options to report.
+#		New Function ProcessDHCPOptions
+#		Update Functions ShowScriptOptions and ProcessScriptEnd 
+#		Update Help Text
+#	Reorder parameters
+#	Update Function SendEmail to handle anonymous unauthenticated email
+#		Update Help Text with examples
+#	Update script to match updates to other documentation scripts
+#		Checking for multiple output formats selected
+#		Change Text output to use [System.Text.StringBuilder]
+#		Function Line
+#		Function SaveandCloseTextDocument
+#		Function WriteWordLine
+#		Function WriteHTMLLine
+#		Function AddHTMLTable
+#		Function FormatHTMLTable
+#		Function FormatHTMLTable
+#		Function CheckHTMLColor
+#
 #Version 1.42 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 
@@ -808,7 +890,7 @@ Param(
 
 
 #region initial variable testing and setup
-Set-StrictMode -Version 2
+Set-StrictMode -Version Latest
 
 #force  on
 $PSDefaultParameterValues = @{"*:Verbose"=$True}
@@ -859,6 +941,37 @@ If($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq 
 }
 
 Write-Verbose "$(Get-Date): Testing output parameters"
+
+#added in V2.21
+$OutputCnt = 0
+
+If($MSWord)
+{
+	$OutputCnt++
+}
+If($PDF)
+{
+	$OutputCnt++
+}
+If($Text)
+{
+	$OutputCnt++
+}
+If($HTML)
+{
+	$OutputCnt++
+}
+
+If($OutputCnt -eq 0)
+{
+	Write-Error "No output parameter detected.  Script cannot continue"
+	Exit
+}
+ElseIf($OutputCnt -gt 1)
+{
+	Write-Error "Multiple output parameters detected.  Script cannot continue"
+	Exit
+}
 
 If($MSWord)
 {
@@ -954,7 +1067,7 @@ If($MSWord -or $PDF)
 	[int]$wdSeekMainDocument = 0
 	[int]$wdSeekPrimaryFooter = 4
 	[int]$wdStory = 6
-	[long]$wdColorRed = 255
+	[int]$wdColorRed = 255
 	[int]$wdColorBlack = 0
 	[int]$wdWord2007 = 12
 	[int]$wdWord2010 = 14
@@ -995,6 +1108,7 @@ If($MSWord -or $PDF)
 	[int]$wdStyleHeading4 = -5
 	[int]$wdStyleNoSpacing = -158
 	[int]$wdTableGrid = -155
+	[int]$wdTableLightListAccent3 = -206
 
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/org/codehaus/groovy/scriptom/tlb/office/word/WdLineStyle.html
 	[int]$wdLineStyleNone = 0
@@ -1002,52 +1116,84 @@ If($MSWord -or $PDF)
 
 	[int]$wdHeadingFormatTrue = -1
 	[int]$wdHeadingFormatFalse = 0 
+	
+	[string]$Script:RunningOS = (Get-WmiObject -class Win32_OperatingSystem -EA 0).Caption
+}
+Else
+{
+	$Script:CoName = ""
 }
 
 If($HTML)
 {
-    Set-Variable htmlredmask         -Option AllScope -Value "#FF0000" 4>$Null
-    Set-Variable htmlcyanmask        -Option AllScope -Value "#00FFFF" 4>$Null
-    Set-Variable htmlbluemask        -Option AllScope -Value "#0000FF" 4>$Null
-    Set-Variable htmldarkbluemask    -Option AllScope -Value "#0000A0" 4>$Null
-    Set-Variable htmllightbluemask   -Option AllScope -Value "#ADD8E6" 4>$Null
-    Set-Variable htmlpurplemask      -Option AllScope -Value "#800080" 4>$Null
-    Set-Variable htmlyellowmask      -Option AllScope -Value "#FFFF00" 4>$Null
-    Set-Variable htmllimemask        -Option AllScope -Value "#00FF00" 4>$Null
-    Set-Variable htmlmagentamask     -Option AllScope -Value "#FF00FF" 4>$Null
-    Set-Variable htmlwhitemask       -Option AllScope -Value "#FFFFFF" 4>$Null
-    Set-Variable htmlsilvermask      -Option AllScope -Value "#C0C0C0" 4>$Null
-    Set-Variable htmlgraymask        -Option AllScope -Value "#808080" 4>$Null
-    Set-Variable htmlblackmask       -Option AllScope -Value "#000000" 4>$Null
-    Set-Variable htmlorangemask      -Option AllScope -Value "#FFA500" 4>$Null
-    Set-Variable htmlmaroonmask      -Option AllScope -Value "#800000" 4>$Null
-    Set-Variable htmlgreenmask       -Option AllScope -Value "#008000" 4>$Null
-    Set-Variable htmlolivemask       -Option AllScope -Value "#808000" 4>$Null
+	#V2.23 Prior versions used Set-Variable. That hid the variables
+	#from @code. So MBS switched to using $global:
 
-    Set-Variable htmlbold        -Option AllScope -Value 1 4>$Null
-    Set-Variable htmlitalics     -Option AllScope -Value 2 4>$Null
-    Set-Variable htmlred         -Option AllScope -Value 4 4>$Null
-    Set-Variable htmlcyan        -Option AllScope -Value 8 4>$Null
-    Set-Variable htmlblue        -Option AllScope -Value 16 4>$Null
-    Set-Variable htmldarkblue    -Option AllScope -Value 32 4>$Null
-    Set-Variable htmllightblue   -Option AllScope -Value 64 4>$Null
-    Set-Variable htmlpurple      -Option AllScope -Value 128 4>$Null
-    Set-Variable htmlyellow      -Option AllScope -Value 256 4>$Null
-    Set-Variable htmllime        -Option AllScope -Value 512 4>$Null
-    Set-Variable htmlmagenta     -Option AllScope -Value 1024 4>$Null
-    Set-Variable htmlwhite       -Option AllScope -Value 2048 4>$Null
-    Set-Variable htmlsilver      -Option AllScope -Value 4096 4>$Null
-    Set-Variable htmlgray        -Option AllScope -Value 8192 4>$Null
-    Set-Variable htmlolive       -Option AllScope -Value 16384 4>$Null
-    Set-Variable htmlorange      -Option AllScope -Value 32768 4>$Null
-    Set-Variable htmlmaroon      -Option AllScope -Value 65536 4>$Null
-    Set-Variable htmlgreen       -Option AllScope -Value 131072 4>$Null
-    Set-Variable htmlblack       -Option AllScope -Value 262144 4>$Null
+    $global:htmlredmask       = "#FF0000" 4>$Null
+    $global:htmlcyanmask      = "#00FFFF" 4>$Null
+    $global:htmlbluemask      = "#0000FF" 4>$Null
+    $global:htmldarkbluemask  = "#0000A0" 4>$Null
+    $global:htmllightbluemask = "#ADD8E6" 4>$Null
+    $global:htmlpurplemask    = "#800080" 4>$Null
+    $global:htmlyellowmask    = "#FFFF00" 4>$Null
+    $global:htmllimemask      = "#00FF00" 4>$Null
+    $global:htmlmagentamask   = "#FF00FF" 4>$Null
+    $global:htmlwhitemask     = "#FFFFFF" 4>$Null
+    $global:htmlsilvermask    = "#C0C0C0" 4>$Null
+    $global:htmlgraymask      = "#808080" 4>$Null
+    $global:htmlblackmask     = "#000000" 4>$Null
+    $global:htmlorangemask    = "#FFA500" 4>$Null
+    $global:htmlmaroonmask    = "#800000" 4>$Null
+    $global:htmlgreenmask     = "#008000" 4>$Null
+    $global:htmlolivemask     = "#808000" 4>$Null
+
+    $global:htmlbold        = 1 4>$Null
+    $global:htmlitalics     = 2 4>$Null
+    $global:htmlred         = 4 4>$Null
+    $global:htmlcyan        = 8 4>$Null
+    $global:htmlblue        = 16 4>$Null
+    $global:htmldarkblue    = 32 4>$Null
+    $global:htmllightblue   = 64 4>$Null
+    $global:htmlpurple      = 128 4>$Null
+    $global:htmlyellow      = 256 4>$Null
+    $global:htmllime        = 512 4>$Null
+    $global:htmlmagenta     = 1024 4>$Null
+    $global:htmlwhite       = 2048 4>$Null
+    $global:htmlsilver      = 4096 4>$Null
+    $global:htmlgray        = 8192 4>$Null
+    $global:htmlolive       = 16384 4>$Null
+    $global:htmlorange      = 32768 4>$Null
+    $global:htmlmaroon      = 65536 4>$Null
+    $global:htmlgreen       = 131072 4>$Null
+	$global:htmlblack       = 262144 4>$Null
+
+	$global:htmlsb          = ( $htmlsilver -bor $htmlBold ) ## point optimization
+
+	$global:htmlColor = 
+	@{
+		$htmlred       = $htmlredmask
+		$htmlcyan      = $htmlcyanmask
+		$htmlblue      = $htmlbluemask
+		$htmldarkblue  = $htmldarkbluemask
+		$htmllightblue = $htmllightbluemask
+		$htmlpurple    = $htmlpurplemask
+		$htmlyellow    = $htmlyellowmask
+		$htmllime      = $htmllimemask
+		$htmlmagenta   = $htmlmagentamask
+		$htmlwhite     = $htmlwhitemask
+		$htmlsilver    = $htmlsilvermask
+		$htmlgray      = $htmlgraymask
+		$htmlolive     = $htmlolivemask
+		$htmlorange    = $htmlorangemask
+		$htmlmaroon    = $htmlmaroonmask
+		$htmlgreen     = $htmlgreenmask
+		$htmlblack     = $htmlblackmask
+	}
 }
 
 If($TEXT)
 {
-	$global:output = ""
+	[System.Text.StringBuilder] $global:Output = New-Object System.Text.StringBuilder( 16384 )
 }
 #endregion
 
@@ -3273,7 +3419,7 @@ Function SaveandCloseTextDocument
 		$Script:FileName1 += "_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 	}
 
-	Write-Output $Global:Output | Out-File $Script:Filename1 4>$Null
+	Write-Output $Global:Output.ToString() | Out-File $Script:Filename1 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
@@ -3432,6 +3578,7 @@ Function ShowScriptOptions
 	Write-Verbose "$(Get-Date): From            : $($From)"
 	Write-Verbose "$(Get-Date): HW Inventory    : $($Hardware)"
 	Write-Verbose "$(Get-Date): Include Leases  : $($IncludeLeases)"
+	Write-Verbose "$(Get-Date): Include Options : $($IncludeOptions)"
 	Write-Verbose "$(Get-Date): Log             : $($Log)"
 	Write-Verbose "$(Get-Date): Save As HTML    : $($HTML)"
 	Write-Verbose "$(Get-Date): Save As PDF     : $($PDF)"
@@ -3776,21 +3923,35 @@ Function Get-RegistryValue($path, $name)
 #region word, text and html line output functions
 Function line
 #function created by Michael B. Smith, Exchange MVP
-#@essentialexchange on Twitter
-#http://TheEssentialExchange.com
+#@essentialexch on Twitter
+#https://essential.exchange/blog
 #for creating the formatted text report
 #created March 2011
 #updated March 2014
+# updated March 2019 to use StringBuilder (about 100 times more efficient than simple strings)
 {
-	Param( [int]$tabs = 0, [string]$name = '', [string]$value = '', [string]$newline = "`r`n", [switch]$nonewline )
-	While( $tabs -gt 0 ) { $Global:Output += "`t"; $tabs--; }
+	Param
+	(
+		[Int]    $tabs = 0, 
+		[String] $name = '', 
+		[String] $value = '', 
+		[String] $newline = [System.Environment]::NewLine, 
+		[Switch] $nonewline
+	)
+
+	while( $tabs -gt 0 )
+	{
+		$null = $global:Output.Append( "`t" )
+		$tabs--
+	}
+
 	If( $nonewline )
 	{
-		$Global:Output += $name + $value
+		$null = $global:Output.Append( $name + $value )
 	}
 	Else
 	{
-		$Global:Output += $name + $value + $newline
+		$null = $global:Output.AppendLine( $name + $value )
 	}
 }
 	
@@ -3962,105 +4123,120 @@ Function WriteHTMLLine
 #Function created to make output to HTML easy in this script
 #headings fixed 12-Oct-2016 by Webster
 #errors with $HTMLStyle fixed 7-Dec-2017 by Webster
+# re-implemented/re-based by Michael B. Smith
 {
-	Param([int]$style=0, 
-	[int]$tabs = 0, 
-	[string]$name = '', 
-	[string]$value = '', 
-	[string]$fontName="Calibri",
-	[int]$fontSize=1,
-	[int]$options=$htmlblack)
+	Param
+	(
+		[Int]    $style    = 0, 
+		[Int]    $tabs     = 0, 
+		[String] $name     = '', 
+		[String] $value    = '', 
+		[String] $fontName = $null,
+		[Int]    $fontSize = 1,
+		[Int]    $options  = $htmlblack
+	)
 
+	## FIXME - long story short, this function was wrong and had been wrong for a long time. 
+	## The function generated invalid HTML, and ignored fontname and fontsize parameters. I fixed
+	## those items, but that made the report unreadable, because all of the formatting had been based
+	## on this function not working properly.
 
-	#Build output style
-	[string]$output = ""
+	## here is a typical H1 previously generated:
+	## <h1>///&nbsp;&nbsp;Forest Information&nbsp;&nbsp;\\\<font face='Calibri' color='#000000' size='1'></h1></font>
 
-	If([String]::IsNullOrEmpty($Name))	
+	## fixing the function generated this (unreadably small):
+	## <h1><font face='Calibri' color='#000000' size='1'>///&nbsp;&nbsp;Forest Information&nbsp;&nbsp;\\\</font></h1>
+
+	## So I took all the fixes out. This routine now generates valid HTML, but the fontName, fontSize,
+	## and options parameters are ignored; so the routine generates equivalent output as before. I took
+	## the fixes out instead of fixing all the call sites, because there are 225 call sites! If you are
+	## willing to update all the call sites, you can easily re-instate the fixes. They have only been
+	## commented out with '##' below.
+
+	## if( [String]::IsNullOrEmpty( $fontName ) )
+	## {
+	##	$fontName = 'Calibri'
+	## }
+	## if( $fontSize -le 0 )
+	## {
+	##	$fontSize = 1
+	## }
+
+	## ## output data is stored here
+	## [String] $output = ''
+	[System.Text.StringBuilder] $sb = New-Object System.Text.StringBuilder( 1024 )
+
+	If( [String]::IsNullOrEmpty( $name ) )	
 	{
-		$HTMLBody = "<p></p>"
+		## $HTMLBody = '<p></p>'
+		$null = $sb.Append( '<p></p>' )
 	}
 	Else
 	{
-		$color = CheckHTMLColor $options
+		[Bool] $ital = $options -band $htmlitalics
+		[Bool] $bold = $options -band $htmlBold
+		## $color = $global:htmlColor[ $options -band 0xffffc ]
 
-		#build # of tabs
+		## ## build the HTML output string
+##		$HTMLBody = ''
+##		if( $ital ) { $HTMLBody += '<i>' }
+##		if( $bold ) { $HTMLBody += '<b>' } 
+		if( $ital ) { $null = $sb.Append( '<i>' ) }
+		if( $bold ) { $null = $sb.Append( '<b>' ) } 
 
-		While($tabs -gt 0)
-		{ 
-			$output += "&nbsp;&nbsp;&nbsp;&nbsp;"; $tabs--; 
+		switch( $style )
+		{
+			1 { $HTMLOpen = '<h1>'; $HTMLClose = '</h1>'; Break }
+			2 { $HTMLOpen = '<h2>'; $HTMLClose = '</h2>'; Break }
+			3 { $HTMLOpen = '<h3>'; $HTMLClose = '</h3>'; Break }
+			4 { $HTMLOpen = '<h4>'; $HTMLClose = '</h4>'; Break }
+			Default { $HTMLOpen = ''; $HTMLClose = ''; Break }
 		}
 
-		$HTMLFontName = $fontName		
+		## $HTMLBody += $HTMLOpen
+		$null = $sb.Append( $HTMLOpen )
 
-		$HTMLBody = ""
-
-		If($options -band $htmlitalics) 
-		{
-			$HTMLBody += "<i>"
-		} 
-
-		If($options -band $htmlbold) 
-		{
-			$HTMLBody += "<b>"
-		} 
-
-		#output the rest of the parameters.
-		$output += $name + $value
-
-		Switch ($style)
-		{
-			1 {$HTMLStyle = "<h1>"; Break}
-			2 {$HTMLStyle = "<h2>"; Break}
-			3 {$HTMLStyle = "<h3>"; Break}
-			4 {$HTMLStyle = "<h4>"; Break}
-			Default {$HTMLStyle = ""; Break}
-		}
-
-		$HTMLBody += $HTMLStyle + $output
-
-		Switch ($style)
-		{
-			1 {$HTMLStyle = "</h1>"; Break}
-			2 {$HTMLStyle = "</h2>"; Break}
-			3 {$HTMLStyle = "</h3>"; Break}
-			4 {$HTMLStyle = "</h4>"; Break}
-			Default {$HTMLStyle = ""; Break}
-		}
-
-		#added by webster 12-oct-2016
-		#if a heading, don't add the <br>
-		#moved to after the two switch statements on 7-Dec-2017 to fix $HTMLStyle has not been set error
-		If($HTMLStyle -eq "")
-		{
-			$HTMLBody += "<br><font face='" + $HTMLFontName + "' " + "color='" + $color + "' size='"  + $fontsize + "'>"
-		}
-		Else
-		{
-			$HTMLBody += "<font face='" + $HTMLFontName + "' " + "color='" + $color + "' size='"  + $fontsize + "'>"
-		}
+		## if($HTMLClose -eq '')
+		## {
+		##	$HTMLBody += "<br><font face='" + $fontName + "' " + "color='" + $color + "' size='"  + $fontSize + "'>"
+		## }
+		## else
+		## {
+		##	$HTMLBody += "<font face='" + $fontName + "' " + "color='" + $color + "' size='"  + $fontSize + "'>"
+		## }
 		
-		$HTMLBody += $HTMLStyle +  "</font>"
+##		while( $tabs -gt 0 )
+##		{ 
+##			$output += '&nbsp;&nbsp;&nbsp;&nbsp;'
+##			$tabs--
+##		}
+		## output the rest of the parameters.
+##		$output += $name + $value
+		## $HTMLBody += $output
+		$null = $sb.Append( ( '&nbsp;&nbsp;&nbsp;&nbsp;' * $tabs ) + $name + $value )
 
-		If($options -band $htmlitalics) 
-		{
-			$HTMLBody += "</i>"
-		} 
+		## $HTMLBody += '</font>'
+##		if( $HTMLClose -eq '' ) { $HTMLBody += '<br>'     }
+##		else                    { $HTMLBody += $HTMLClose }
 
-		If($options -band $htmlbold) 
-		{
-			$HTMLBody += "</b>"
-		} 
+##		if( $ital ) { $HTMLBody += '</i>' }
+##		if( $bold ) { $HTMLBody += '</b>' } 
 
-		#added by webster 12-oct-2016
-		#if a heading, don't add the <br />
-		#moved to inside the Else statement on 7-Dec-2017 to fix $HTMLStyle has not been set error
-		If($HTMLStyle -eq "")
-		{
-			$HTMLBody += "<br />"
-		}
+##		if( $HTMLClose -eq '' ) { $HTMLBody += '<br />' }
+
+		if( $HTMLClose -eq '' ) { $null = $sb.Append( '<br>' )     }
+		else                    { $null = $sb.Append( $HTMLClose ) }
+
+		if( $ital ) { $null = $sb.Append( '</i>' ) }
+		if( $bold ) { $null = $sb.Append( '</b>' ) } 
+
+		if( $HTMLClose -eq '' ) { $null = $sb.Append( '<br />' ) }
 	}
+	##$HTMLBody += $crlf
+	$null = $sb.AppendLine( '' )
 
-	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null
+##	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null
+	Out-File -FilePath $Script:FileName1 -Append -InputObject $sb.ToString() 4>$Null
 }
 #endregion
 
@@ -4069,110 +4245,254 @@ Function WriteHTMLLine
 # AddHTMLTable - Called from FormatHTMLTable function
 # Created by Ken Avram
 # modified by Jake Rutski
+# re-implemented by Michael B. Smith for v2.23. Also made the documentation match reality.
 #***********************************************************************************************************
 Function AddHTMLTable
 {
-	Param([string]$fontName="Calibri",
-	[int]$fontSize=2,
-	[int]$colCount=0,
-	[int]$rowCount=0,
-	[object[]]$rowInfo=@(),
-	[object[]]$fixedInfo=@())
+	Param
+	(
+		[String]   $fontName  = 'Calibri',
+		[Int]      $fontSize  = 2,
+		[Int]      $colCount  = 0,
+		[Int]      $rowCount  = 0,
+		[Object[]] $rowInfo   = $null,
+		[Object[]] $fixedInfo = $null
+	)
+	## Use StringBuilder - MBS
+	## In the normal case, tables are only a few dozen cells. But in the case
+	## of Sites, OUs, and Users - there may be many hundreds of thousands of 
+	## cells. Using normal strings is too slow.
 
-	For($rowidx = $RowIndex;$rowidx -le $rowCount;$rowidx++)
+	## if( $ExtraSpecialVerbose )
+	## {
+	##	$global:rowInfo1 = $rowInfo
+	## }
+<#
+	if( $SuperVerbose )
 	{
-		$rd = @($rowInfo[$rowidx - 2])
-		$htmlbody = $htmlbody + "<tr>"
-		For($columnIndex = 0; $columnIndex -lt $colCount; $columnindex+=2)
+		wv "AddHTMLTable: fontName '$fontName', fontsize $fontSize, colCount $colCount, rowCount $rowCount"
+		if( $null -ne $rowInfo -and $rowInfo.Count -gt 0 )
 		{
-			$tmp = CheckHTMLColor $rd[$columnIndex+1]
-
-			If($fixedInfo.Length -eq 0)
+			wv "AddHTMLTable: rowInfo has $( $rowInfo.Count ) elements"
+			if( $ExtraSpecialVerbose )
 			{
-				$htmlbody += "<td style=""background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
-			}
-			Else
-			{
-				$htmlbody += "<td style=""width:$($fixedInfo[$columnIndex/2]); background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
-			}
-
-			If($rd[$columnIndex+1] -band $htmlbold)
-			{
-				$htmlbody += "<b>"
-			}
-			If($rd[$columnIndex+1] -band $htmlitalics)
-			{
-				$htmlbody += "<i>"
-			}
-			If($Null -ne $rd[$columnIndex])
-			{
-				$cell = $rd[$columnIndex].tostring()
-				If($cell -eq " " -or $cell.length -eq 0)
+				wv "AddHTMLTable: rowInfo length $( $rowInfo.Length )"
+				for( $ii = 0; $ii -lt $rowInfo.Length; $ii++ )
 				{
-					$htmlbody += "&nbsp;&nbsp;&nbsp;"
-				}
-				Else
-				{
-					For($i=0;$i -lt $cell.length;$i++)
+					$row = $rowInfo[ $ii ]
+					wv "AddHTMLTable: index $ii, type $( $row.GetType().FullName ), length $( $row.Length )"
+					for( $yyy = 0; $yyy -lt $row.Length; $yyy++ )
 					{
-						If($cell[$i] -eq " ")
-						{
-							$htmlbody += "&nbsp;"
-						}
-						If($cell[$i] -ne " ")
-						{
-							Break
-						}
+						wv "AddHTMLTable: index $ii, yyy = $yyy, val = '$( $row[ $yyy ] )'"
 					}
-					$htmlbody += $cell
+					wv "AddHTMLTable: done"
 				}
 			}
-			Else
-			{
-				$htmlbody += "&nbsp;&nbsp;&nbsp;"
-			}
-			If($rd[$columnIndex+1] -band $htmlbold)
-			{
-				$htmlbody += "</b>"
-			}
-			If($rd[$columnIndex+1] -band $htmlitalics)
-			{
-				$htmlbody += "</i>"
-			}
-			$htmlbody += "</font></td>"
 		}
-		$htmlbody += "</tr>"
+		else
+		{
+			wv "AddHTMLTable: rowInfo is empty"
+		}
+		if( $null -ne $fixedInfo -and $fixedInfo.Count -gt 0 )
+		{
+			wv "AddHTMLTable: fixedInfo has $( $fixedInfo.Count ) elements"
+		}
+		else
+		{
+			wv "AddHTMLTable: fixedInfo is empty"
+		}
 	}
-	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null 
+#>
+
+	##$htmlbody = ''
+	[System.Text.StringBuilder] $sb = New-Object System.Text.StringBuilder( 8192 )
+
+	if( $rowInfo -and $rowInfo.Length -lt $rowCount )
+	{
+##		$oldCount = $rowCount
+		$rowCount = $rowInfo.Length
+##		if( $SuperVerbose )
+##		{
+##			wv "AddHTMLTable: updated rowCount to $rowCount from $oldCount, based on rowInfo.Length"
+##		}
+	}
+
+	for( $rowCountIndex = 0; $rowCountIndex -lt $rowCount; $rowCountIndex++ )
+	{
+		$null = $sb.AppendLine( '<tr>' )
+		## $htmlbody += '<tr>'
+		## $htmlbody += $crlf - make the HTML readable
+
+		## each row of rowInfo is an array
+		## each row consists of tuples: an item of text followed by an item of formatting data
+<#		
+		$row = $rowInfo[ $rowCountIndex ]
+		if( $ExtraSpecialVerbose )
+		{
+			wv "!!!!! AddHTMLTable: rowCountIndex = $rowCountIndex, row.Length = $( $row.Length ), row gettype = $( $row.GetType().FullName )"
+			wv "!!!!! AddHTMLTable: colCount $colCount"
+			wv "!!!!! AddHTMLTable: row[0].Length $( $row[0].Length )"
+			wv "!!!!! AddHTMLTable: row[0].GetType $( $row[0].GetType().FullName )"
+			$subRow = $row
+			if( $subRow -is [Array] -and $subRow[ 0 ] -is [Array] )
+			{
+				$subRow = $subRow[ 0 ]
+				wv "!!!!! AddHTMLTable: deref subRow.Length $( $subRow.Length ), subRow.GetType $( $subRow.GetType().FullName )"
+			}
+
+			for( $columnIndex = 0; $columnIndex -lt $subRow.Length; $columnIndex += 2 )
+			{
+				$item = $subRow[ $columnIndex ]
+				wv "!!!!! AddHTMLTable: item.GetType $( $item.GetType().FullName )"
+				## if( !( $item -is [String] ) -and $item -is [Array] )
+##				if( $item -is [Array] -and $item[ 0 ] -is [Array] )				
+##				{
+##					$item = $item[ 0 ]
+##					wv "!!!!! AddHTMLTable: dereferenced item.GetType $( $item.GetType().FullName )"
+##				}
+				wv "!!!!! AddHTMLTable: rowCountIndex = $rowCountIndex, columnIndex = $columnIndex, val '$item'"
+			}
+			wv "!!!!! AddHTMLTable: done"
+		}
+#>
+
+		## reset
+		$row = $rowInfo[ $rowCountIndex ]
+
+		$subRow = $row
+		if( $subRow -is [Array] -and $subRow[ 0 ] -is [Array] )
+		{
+			$subRow = $subRow[ 0 ]
+			## wv "***** AddHTMLTable: deref rowCountIndex $rowCountIndex, subRow.Length $( $subRow.Length ), subRow.GetType $( $subRow.GetType().FullName )"
+		}
+
+		$subRowLength = $subRow.Length
+		for( $columnIndex = 0; $columnIndex -lt $colCount; $columnIndex += 2 )
+		{
+			$item = if( $columnIndex -lt $subRowLength ) { $subRow[ $columnIndex ] } else { 0 }
+			## if( !( $item -is [String] ) -and $item -is [Array] )
+##			if( $item -is [Array] -and $item[ 0 ] -is [Array] )
+##			{
+##				$item = $item[ 0 ]
+##			}
+
+			$text   = if( $item ) { $item.ToString() } else { '' }
+			$format = if( ( $columnIndex + 1 ) -lt $subRowLength ) { $subRow[ $columnIndex + 1 ] } else { 0 }
+			## item, text, and format ALWAYS have values, even if empty values
+			$color  = $global:htmlColor[ $format -band 0xffffc ]
+			[Bool] $bold = $format -band $htmlBold
+			[Bool] $ital = $format -band $htmlitalics
+<#			
+			if( $ExtraSpecialVerbose )
+			{
+				wv "***** columnIndex $columnIndex, subRow.Length $( $subRow.Length ), item GetType $( $item.GetType().FullName ), item '$item'"
+				wv "***** format $format, color $color, text '$text'"
+				wv "***** format gettype $( $format.GetType().Fullname ), text gettype $( $text.GetType().Fullname )"
+			}
+#>
+
+			if( $null -eq $fixedInfo -or $fixedInfo.Length -eq 0 )
+			{
+				$null = $sb.Append( "<td style=""background-color:$( $color )""><font face='$( $fontName )' size='$( $fontSize )'>" )
+				##$htmlbody += "<td style=""background-color:$( $color )""><font face='$( $fontName )' size='$( $fontSize )'>"
+			}
+			else
+			{
+				$null = $sb.Append( "<td style=""width:$( $fixedInfo[ $columnIndex / 2 ] ); background-color:$( $color )""><font face='$( $fontName )' size='$( $fontSize )'>" )
+				##$htmlbody += "<td style=""width:$( $fixedInfo[ $columnIndex / 2 ] ); background-color:$( $color )""><font face='$( $fontName )' size='$( $fontSize )'>"
+			}
+
+			##if( $bold ) { $htmlbody += '<b>' }
+			##if( $ital ) { $htmlbody += '<i>' }
+			if( $bold ) { $null = $sb.Append( '<b>' ) }
+			if( $ital ) { $null = $sb.Append( '<i>' ) }
+
+			if( $text -eq ' ' -or $text.length -eq 0)
+			{
+				##$htmlbody += '&nbsp;&nbsp;&nbsp;'
+				$null = $sb.Append( '&nbsp;&nbsp;&nbsp;' )
+			}
+			else
+			{
+				for ($inx = 0; $inx -lt $text.length; $inx++ )
+				{
+					if( $text[ $inx ] -eq ' ' )
+					{
+						##$htmlbody += '&nbsp;'
+						$null = $sb.Append( '&nbsp;' )
+					}
+					else
+					{
+						break
+					}
+				}
+				##$htmlbody += $text
+				$null = $sb.Append( $text )
+			}
+
+##			if( $bold ) { $htmlbody += '</b>' }
+##			if( $ital ) { $htmlbody += '</i>' }
+			if( $bold ) { $null = $sb.Append( '</b>' ) }
+			if( $ital ) { $null = $sb.Append( '</i>' ) }
+
+			$null = $sb.AppendLine( '</font></td>' )
+##			$htmlbody += '</font></td>'
+##			$htmlbody += $crlf
+		}
+
+		$null = $sb.AppendLine( '</tr>' )
+##		$htmlbody += '</tr>'
+##		$htmlbody += $crlf
+	}
+
+##	if( $ExtraSpecialVerbose )
+##	{
+##		$global:rowInfo = $rowInfo
+##		wv "!!!!! AddHTMLTable: HTML = '$htmlbody'"
+##	}
+
+##	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null 
+	Out-File -FilePath $Script:FileName1 -Append -InputObject $sb.ToString() 4>$Null 
 }
 
 #***********************************************************************************************************
 # FormatHTMLTable 
 # Created by Ken Avram
 # modified by Jake Rutski
+# reworked by Michael B. Smith for v2.23
 #***********************************************************************************************************
 
 <#
 .Synopsis
-	Format table for HTML output document
+	Format table for a HTML output document.
 .DESCRIPTION
-	This function formats a table for HTML from an array of strings
+	This function formats a table for HTML from multiple arrays of strings.
 .PARAMETER noBorder
-	If set to $true, a table will be generated without a border (border='0')
+	If set to $true, a table will be generated without a border (border = '0'). Otherwise the table will be generated
+	with a border (border = '1').
 .PARAMETER noHeadCols
-	This parameter should be used when generating tables without column headers
-	Set this parameter equal to the number of columns in the table
+	This parameter should be used when generating tables which do not have a separate array containing column headers
+	(columnArray is not specified). Set this parameter equal to the number of columns in the table.
 .PARAMETER rowArray
-	This parameter contains the row data array for the table
+	This parameter contains the row data array for the table.
 .PARAMETER columnArray
-	This parameter contains column header data for the table
+	This parameter contains column header data for the table.
 .PARAMETER fixedWidth
 	This parameter contains widths for columns in pixel format ("100px") to override auto column widths
 	The variable should contain a width for each column you wish to override the auto-size setting
-	For example: $columnWidths = @("100px","110px","120px","130px","140px")
+	For example: $fixedWidth = @("100px","110px","120px","130px","140px")
+.PARAMETER tableHeader
+	A string containing the header for the table (printed at the top of the table, left justified). The
+	default is a blank string.
+.PARAMETER tableWidth
+	The width of the table in pixels, or 'auto'. The default is 'auto'.
+.PARAMETER fontName
+	The name of the font to use in the table. The default is 'Calibri'.
+.PARAMETER fontSize
+	The size of the font to use in the table. The default is 2. Note that this is the HTML size, not the pixel size.
 
 .USAGE
-	FormatHTMLTable <Table Header> <Table Format> <Font Name> <Font Size>
+	FormatHTMLTable <Table Header> <Table Width> <Font Name> <Font Size>
 
 .EXAMPLE
 	FormatHTMLTable "Table Heading" "auto" "Calibri" 3
@@ -4205,7 +4525,7 @@ Function AddHTMLTable
 	Then Load the array.  If you are using column headers then load those into the column headers array, otherwise the first line of the table goes into the column headers array
 	and the second and subsequent lines go into the $rowdata table as shown below:
 
-	$columnHeaders = @('Display Name',($htmlsilver -bor $htmlbold),'Status',($htmlsilver -bor $htmlbold),'Startup Type',($htmlsilver -bor $htmlbold))
+	$columnHeaders = @('Display Name',$htmlsb,'Status',$htmlsb,'Startup Type',$htmlsb)
 
 	The first column is the actual name to display, the second are the attributes of the column i.e. color anded with bold or italics.  For the anding, parens are required or it will
 	not format correctly.
@@ -4213,18 +4533,18 @@ Function AddHTMLTable
 	This is following by adding rowdata as shown below.  As more columns are added the columns will auto adjust to fit the size of the page.
 
 	$rowdata = @()
-	$columnHeaders = @("User Name",($htmlsilver -bor $htmlbold),$UserName,$htmlwhite)
-	$rowdata += @(,('Save as PDF',($htmlsilver -bor $htmlbold),$PDF.ToString(),$htmlwhite))
-	$rowdata += @(,('Save as TEXT',($htmlsilver -bor $htmlbold),$TEXT.ToString(),$htmlwhite))
-	$rowdata += @(,('Save as WORD',($htmlsilver -bor $htmlbold),$MSWORD.ToString(),$htmlwhite))
-	$rowdata += @(,('Save as HTML',($htmlsilver -bor $htmlbold),$HTML.ToString(),$htmlwhite))
-	$rowdata += @(,('Add DateTime',($htmlsilver -bor $htmlbold),$AddDateTime.ToString(),$htmlwhite))
-	$rowdata += @(,('Hardware Inventory',($htmlsilver -bor $htmlbold),$Hardware.ToString(),$htmlwhite))
-	$rowdata += @(,('Computer Name',($htmlsilver -bor $htmlbold),$ComputerName,$htmlwhite))
-	$rowdata += @(,('Filename1',($htmlsilver -bor $htmlbold),$Script:FileName1,$htmlwhite))
-	$rowdata += @(,('OS Detected',($htmlsilver -bor $htmlbold),$Script:RunningOS,$htmlwhite))
-	$rowdata += @(,('PSUICulture',($htmlsilver -bor $htmlbold),$PSCulture,$htmlwhite))
-	$rowdata += @(,('PoSH version',($htmlsilver -bor $htmlbold),$Host.Version.ToString(),$htmlwhite))
+	$columnHeaders = @("User Name",$htmlsb,$UserName,$htmlwhite)
+	$rowdata += @(,('Save as PDF',$htmlsb,$PDF.ToString(),$htmlwhite))
+	$rowdata += @(,('Save as TEXT',$htmlsb,$TEXT.ToString(),$htmlwhite))
+	$rowdata += @(,('Save as WORD',$htmlsb,$MSWORD.ToString(),$htmlwhite))
+	$rowdata += @(,('Save as HTML',$htmlsb,$HTML.ToString(),$htmlwhite))
+	$rowdata += @(,('Add DateTime',$htmlsb,$AddDateTime.ToString(),$htmlwhite))
+	$rowdata += @(,('Hardware Inventory',$htmlsb,$Hardware.ToString(),$htmlwhite))
+	$rowdata += @(,('Computer Name',$htmlsb,$ComputerName,$htmlwhite))
+	$rowdata += @(,('Filename1',$htmlsb,$Script:FileName1,$htmlwhite))
+	$rowdata += @(,('OS Detected',$htmlsb,$Script:RunningOS,$htmlwhite))
+	$rowdata += @(,('PSUICulture',$htmlsb,$PSCulture,$htmlwhite))
+	$rowdata += @(,('PoSH version',$htmlsb,$Host.Version.ToString(),$htmlwhite))
 	FormatHTMLTable "Example of Horizontal AutoFitContents HTML Table" -rowArray $rowdata
 
 	The 'rowArray' paramater is mandatory to build the table, but it is not set as such in the function - if nothing is passed, the table will be empty.
@@ -4255,19 +4575,56 @@ Function AddHTMLTable
 
 Function FormatHTMLTable
 {
-	Param([string]$tableheader,
-	[string]$tablewidth="auto",
-	[string]$fontName="Calibri",
-	[int]$fontSize=2,
-	[switch]$noBorder=$false,
-	[int]$noHeadCols=1,
-	[object[]]$rowArray=@(),
-	[object[]]$fixedWidth=@(),
-	[object[]]$columnArray=@())
+	Param
+	(
+		[String]   $tableheader = '',
+		[String]   $tablewidth  = 'auto',
+		[String]   $fontName    = 'Calibri',
+		[Int]      $fontSize    = 2,
+		[Switch]   $noBorder    = $false,
+		[Int]      $noHeadCols  = 1,
+		[Object[]] $rowArray    = $null,
+		[Object[]] $fixedWidth  = $null,
+		[Object[]] $columnArray = $null
+	)
 
-	$HTMLBody = "<b><font face='" + $fontname + "' size='" + ($fontsize + 1) + "'>" + $tableheader + "</font></b>"
+	## FIXME - the help text for this function is wacky wrong - MBS
+	## FIXME - Use StringBuilder - MBS - this only builds the table header - benefit relatively small
+<#
+	if( $SuperVerbose )
+	{
+		wv "FormatHTMLTable: fontname '$fontname', size $fontSize, tableheader '$tableheader'"
+		wv "FormatHTMLTable: noborder $noborder, noheadcols $noheadcols"
+		if( $rowarray -and $rowarray.count -gt 0 )
+		{
+			wv "FormatHTMLTable: rowarray has $( $rowarray.count ) elements"
+		}
+		else
+		{
+			wv "FormatHTMLTable: rowarray is empty"
+		}
+		if( $columnarray -and $columnarray.count -gt 0 )
+		{
+			wv "FormatHTMLTable: columnarray has $( $columnarray.count ) elements"
+		}
+		else
+		{
+			wv "FormatHTMLTable: columnarray is empty"
+		}
+		if( $fixedwidth -and $fixedwidth.count -gt 0 )
+		{
+			wv "FormatHTMLTable: fixedwidth has $( $fixedwidth.count ) elements"
+		}
+		else
+		{
+			wv "FormatHTMLTable: fixedwidth is empty"
+		}
+	}
+#>
 
-	If($columnArray.Length -eq 0)
+	$HTMLBody = "<b><font face='" + $fontname + "' size='" + ($fontsize + 1) + "'>" + $tableheader + "</font></b>" + $crlf
+
+	If( $null -eq $columnArray -or $columnArray.Length -eq 0)
 	{
 		$NumCols = $noHeadCols + 1
 	}  # means we have no column headers, just a table
@@ -4276,7 +4633,7 @@ Function FormatHTMLTable
 		$NumCols = $columnArray.Length
 	}  # need to add one for the color attrib
 
-	If($Null -ne $rowArray)
+	If( $null -ne $rowArray )
 	{
 		$NumRows = $rowArray.length + 1
 	}
@@ -4285,93 +4642,119 @@ Function FormatHTMLTable
 		$NumRows = 1
 	}
 
-	If($noBorder)
+	If( $noBorder )
 	{
-		$htmlbody += "<table border='0' width='" + $tablewidth + "'>"
+		$HTMLBody += "<table border='0' width='" + $tablewidth + "'>"
 	}
 	Else
 	{
-		$htmlbody += "<table border='1' width='" + $tablewidth + "'>"
+		$HTMLBody += "<table border='1' width='" + $tablewidth + "'>"
 	}
+	$HTMLBody += $crlf
 
-	If(!($columnArray.Length -eq 0))
+	if( $columnArray -and $columnArray.Length -gt 0 )
 	{
-		$htmlbody += "<tr>"
+		$HTMLBody += '<tr>' + $crlf
 
-		For($columnIndex = 0; $columnIndex -lt $NumCols; $columnindex+=2)
+		for( $columnIndex = 0; $columnIndex -lt $NumCols; $columnindex += 2 )
 		{
-			$tmp = CheckHTMLColor $columnArray[$columnIndex+1]
-			If($fixedWidth.Length -eq 0)
+			$val = $columnArray[ $columnIndex + 1 ]
+			$tmp = $global:htmlColor[ $val -band 0xffffc ]
+			[Bool] $bold = $val -band $htmlBold
+			[Bool] $ital = $val -band $htmlitalics
+
+			if( $null -eq $fixedWidth -or $fixedWidth.Length -eq 0 )
 			{
-				$htmlbody += "<td style=""background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
+				$HTMLBody += "<td style=""background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
 			}
-			Else
+			else
 			{
-				$htmlbody += "<td style=""width:$($fixedWidth[$columnIndex/2]); background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
+				$HTMLBody += "<td style=""width:$($fixedWidth[$columnIndex/2]); background-color:$($tmp)""><font face='$($fontName)' size='$($fontSize)'>"
 			}
 
-			If($columnArray[$columnIndex+1] -band $htmlbold)
+			if( $bold ) { $HTMLBody += '<b>' }
+			if( $ital ) { $HTMLBody += '<i>' }
+
+			$array = $columnArray[ $columnIndex ]
+			if( $array )
 			{
-				$htmlbody += "<b>"
-			}
-			If($columnArray[$columnIndex+1] -band $htmlitalics)
-			{
-				$htmlbody += "<i>"
-			}
-			If($Null -ne $columnArray[$columnIndex])
-			{
-				If($columnArray[$columnIndex] -eq " " -or $columnArray[$columnIndex].length -eq 0)
+				if( $array -eq ' ' -or $array.Length -eq 0 )
 				{
-					$htmlbody += "&nbsp;&nbsp;&nbsp;"
+					$HTMLBody += '&nbsp;&nbsp;&nbsp;'
 				}
-				Else
+				else
 				{
-					For($i=0;$i -lt $columnArray[$columnIndex].length;$i+=2)
+					for( $i = 0; $i -lt $array.Length; $i += 2 )
 					{
-						If($columnArray[$columnIndex][$i] -eq " ")
+						if( $array[ $i ] -eq ' ' )
 						{
-							$htmlbody += "&nbsp;"
+							$HTMLBody += '&nbsp;'
 						}
-						If($columnArray[$columnIndex][$i] -ne " ")
+						else
 						{
-							Break
+							break
 						}
 					}
-					$htmlbody += $columnArray[$columnIndex]
+					$HTMLBody += $array
 				}
 			}
-			Else
+			else
 			{
-				$htmlbody += "&nbsp;&nbsp;&nbsp;"
+				$HTMLBody += '&nbsp;&nbsp;&nbsp;'
 			}
-			If($columnArray[$columnIndex+1] -band $htmlbold)
-			{
-				$htmlbody += "</b>"
-			}
-			If($columnArray[$columnIndex+1] -band $htmlitalics)
-			{
-				$htmlbody += "</i>"
-			}
-			$htmlbody += "</font></td>"
+			
+			if( $bold ) { $HTMLBody += '</b>' }
+			if( $ital ) { $HTMLBody += '</i>' }
 		}
-		$htmlbody += "</tr>"
+
+		$HTMLBody += '</font></td>'
+		$HTMLBody += $crlf
 	}
-	$rowindex = 2
-	If($Null -ne $rowArray)
+
+	$HTMLBody += '</tr>' + $crlf
+
+	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null 
+	$HTMLBody = ''
+
+	##$rowindex = 2
+	If( $rowArray )
 	{
-		AddHTMLTable $fontName $fontSize -colCount $numCols -rowCount $NumRows -rowInfo $rowArray -fixedInfo $fixedWidth
-		$rowArray = @()
-		$htmlbody = "</table>"
+<#
+		if( $ExtraSpecialVerbose )
+		{
+			wv "***** FormatHTMLTable: rowarray length $( $rowArray.Length )"
+			for( $ii = 0; $ii -lt $rowArray.Length; $ii++ )
+			{
+				$row = $rowArray[ $ii ]
+				wv "***** FormatHTMLTable: index $ii, type $( $row.GetType().FullName ), length $( $row.Length )"
+				for( $yyy = 0; $yyy -lt $row.Length; $yyy++ )
+				{
+					wv "***** FormatHTMLTable: index $ii, yyy = $yyy, val = '$( $row[ $yyy ] )'"
+				}
+				wv "***** done"
+			}
+			wv "***** FormatHTMLTable: rowCount $NumRows"
+		}
+#>
+
+		AddHTMLTable -fontName $fontName -fontSize $fontSize `
+			-colCount $numCols -rowCount $NumRows `
+			-rowInfo $rowArray -fixedInfo $fixedWidth
+		##$rowArray = @()
+		$rowArray = $null
+		$HTMLBody = '</table>'
 	}
 	Else
 	{
-		$HTMLBody += "</table>"
-	}	
+		$HTMLBody += '</table>'
+	}
+
 	Out-File -FilePath $Script:FileName1 -Append -InputObject $HTMLBody 4>$Null 
 }
 #endregion
 
 #region other HTML functions
+<#
 #***********************************************************************************************************
 # CheckHTMLColor - Called from AddHTMLTable WriteHTMLLine and FormatHTMLTable
 #***********************************************************************************************************
@@ -4379,6 +4762,8 @@ Function CheckHTMLColor
 {
 	Param($hash)
 
+	#V2.23 -- this is really slow. several ways to fixit. so fixit. MBS
+	#V2.23 - obsolete. replaced by using $global:htmlColor lookup table
 	If($hash -band $htmlwhite)
 	{
 		Return $htmlwhitemask
@@ -4448,6 +4833,7 @@ Function CheckHTMLColor
 		Return $htmlolivemask
 	}
 }
+#>
 
 Function SetupHTML
 {
@@ -4462,7 +4848,7 @@ Function SetupHTML
 	}
 
 	$htmlhead = "<html><head><meta http-equiv='Content-Language' content='da'><title>" + $Script:Title + "</title></head><body>"
-	Out-File -FilePath $Script:Filename1 -Force -InputObject $HTMLHead 4>$Null
+	out-file -FilePath $Script:Filename1 -Force -InputObject $HTMLHead 4>$Null
 }#endregion
 
 #region Iain's Word table functions
@@ -4922,13 +5308,14 @@ Function SendEmail
 {
 	Param([string]$Attachments)
 	Write-Verbose "$(Get-Date): Prepare to email"
-	
+
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
 	$emailBody = @"
 Hello, <br />
 <br />
 $Script:Title is attached.
+
 "@ 
 
 	If($Dev)
@@ -4937,66 +5324,105 @@ $Script:Title is attached.
 	}
 
 	$error.Clear()
-
-	If($UseSSL)
+	
+	If($From -Like "anonymous@*")
 	{
-		Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-		-UseSSL *>$Null
-	}
-	Else
-	{
-		Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
-		Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
-		-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
-	}
-
-	$e = $error[0]
-
-	If($e.Exception.ToString().Contains("5.7.57"))
-	{
-		#The server response was: 5.7.57 SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-		Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
-
-		If($Dev)
-		{
-			Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
-		}
-
-		$error.Clear()
-
-		$emailCredentials = Get-Credential -Message "Enter the email account and password to send email"
+		#https://serverfault.com/questions/543052/sending-unauthenticated-mail-through-ms-exchange-with-powershell-windows-server
+		$anonUsername = "anonymous"
+		$anonPassword = ConvertTo-SecureString -String "anonymous" -AsPlainText -Force
+		$anonCredentials = New-Object System.Management.Automation.PSCredential($anonUsername,$anonPassword)
 
 		If($UseSSL)
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-UseSSL -credential $emailCredentials *>$Null 
+			-UseSSL -credential $anonCredentials *>$Null 
 		}
 		Else
 		{
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
-			-credential $emailCredentials *>$Null 
+			-credential $anonCredentials *>$Null 
 		}
-
-		$e = $error[0]
-
-		If($? -and $Null -eq $e)
+		
+		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
 		}
-		Else
+		ElseIf(!$?)
 		{
+			$e = $error[0]
+
 			Write-Verbose "$(Get-Date): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Email was not sent:"
-		Write-Warning "$(Get-Date): Exception: $e.Exception" 
+		If($UseSSL)
+		{
+			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+			-UseSSL *>$Null
+		}
+		Else
+		{
+			Write-Verbose  "$(Get-Date): Trying to send email using current user's credentials without SSL"
+			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To *>$Null
+		}
+
+		If(!$?)
+		{
+			$e = $error[0]
+			
+			#error 5.7.57 is O365 and error 5.7.0 is gmail
+			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
+			{
+				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
+				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+
+				If($Dev)
+				{
+					Out-File -FilePath $Script:DevErrorFile -InputObject $error -Append 4>$Null
+				}
+
+				$error.Clear()
+
+				$emailCredentials = Get-Credential -UserName $From -Message "Enter the password to send email"
+
+				If($UseSSL)
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-UseSSL -credential $emailCredentials *>$Null 
+				}
+				Else
+				{
+					Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
+					-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
+					-credential $emailCredentials *>$Null 
+				}
+
+				If($?)
+				{
+					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+				}
+				ElseIf(!$?)
+				{
+					$e = $error[0]
+
+					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Warning "$(Get-Date): Exception: $e.Exception" 
+				}
+			}
+			Else
+			{
+				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Warning "$(Get-Date): Exception: $e.Exception" 
+			}
+		}
 	}
 }
 #endregion
@@ -11366,6 +11792,153 @@ Function ProcessIPv6Properties
 	}
 }
 
+Function ProcessDHCPOptions
+{
+	Write-Verbose "$(Get-Date):Getting DHCP Options"
+	
+	$DHCPOptions = Get-DhcpServerV4OptionDefinition -ComputerName $Script:DHCPServerName -EA 0
+	
+	If($? -or $Null -ne $DHCPOptions)
+	{
+		Write-Verbose "$(Get-Date): `tProcessing DHCP Options"
+		$DHCPOptions = $DHCPOptions | Sort-Object OptionId
+	
+		If($MSWord -or $PDF)
+		{
+			[System.Collections.Hashtable[]] $ItemsWordTable = @();
+			$Selection.InsertNewPage()
+			WriteWordLine 2 0 "DHCP Options"
+		}
+		ElseIf($Text)
+		{
+			Line 0 "DHCP Options"
+			Line 0 ""
+			Line 1 "OptionId  Name                                                Description                                                   Type          Vendor Class  Default Value         Multivalued"
+			Line 1 "========================================================================================================================================================================================="
+			       #12345678SS12345678901234567890123456789012345678901234567890SS123456789012345678901234567890123456789012345678901234567890SS123456789012SS123456789012SS12345678901234567890SS12345
+		}
+		ElseIf($HTML)
+		{
+			$rowdata = @()
+			WriteHTMLLine 2 0 "DHCP Options"
+		}
+
+		ForEach($Item in $DHCPOptions)
+		{
+			If($MSWord -or $PDF)
+			{
+				$ItemsWordTable += @{ 
+					OptionId     = $Item.OptionId;
+					Name         = $Item.Name;
+					Description  = $Item.Description;
+					Type         = $Item.Type;
+					VendorClass  = $Item.VendorClass;
+					DefaultValue = $Item.DefaultValue;
+					MultiValued  = $Item.MultiValued;
+				}
+			}
+			ElseIf($Text)
+			{
+				Line 1 ( "{0,-8}  {1,-50}  {2,-60}  {3,-12}  {4,-12}  {5,-20}  {6,-8}" -f `
+					$Item.OptionId, 
+					$Item.Name, 
+					$Item.Description, 
+					$Item.Type, 
+					$Item.VendorClass, 
+					$( If( $null –ne $Item.DefaultValue ) { $Item.DefaultValue –join ';' } Else { ' ' } ), 
+					$Item.MultiValued.ToString() 
+				)
+			}
+			ElseIf($HTML)
+			{
+				$tmpDV = $Item.DefaultValue.SyncRoot
+				$rowdata += @(,(
+					$Item.OptionId,$htmlwhite,
+					$Item.Name,$htmlwhite,
+					$Item.Description,$htmlwhite,
+					$Item.Type,$htmlwhite,
+					$Item.VendorClass,$htmlwhite,
+					$tmpDV,$htmlwhite,
+					$Item.MultiValued.ToString(),$htmlwhite
+				))
+			}
+		}
+
+		If($MSWord -or $PDF)
+		{
+			$Table = AddWordTable -Hashtable $ItemsWordTable `
+			-Columns OptionId, Name, Description, Type, VendorClass, DefaultValue, MultiValued `
+			-Headers  "OptionId", "Name", "Description", "Type", "Vendor Class", "Default Value", "Multivalued" `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table -Size 9
+
+			SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 55;
+			$Table.Columns.Item(2).Width = 90;
+			$Table.Columns.Item(3).Width = 115;
+			$Table.Columns.Item(4).Width = 60;
+			$Table.Columns.Item(5).Width = 60;
+			$Table.Columns.Item(6).Width = 60;
+			$Table.Columns.Item(7).Width = 60;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+		}
+		ElseIf($HTML)
+		{
+			$columnHeaders = @(
+			'OptionId',($htmlsilver -bor $htmlBold),
+			'Name',($htmlsilver -bor $htmlBold),
+			'Description',($htmlsilver -bor $htmlBold),
+			'Type',($htmlsilver -bor $htmlBold),
+			'Vendor Class',($htmlsilver -bor $htmlBold),
+			'Default Value',($htmlsilver -bor $htmlBold),
+			'Multivalued',($htmlsilver -bor $htmlBold)
+			)
+
+			$msg = ""
+			$columnWidths = @("60","130","180","80","85","85","80")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "700"
+			WriteHTMLLine 0 0 " "
+		}
+	}
+	ElseIf(!$?)
+	{
+		If($MSWord -or $PDF)
+		{
+			WriteWordLine 0 0 "Error retrieving DHCP Options"
+		}
+		ElseIf($Text)
+		{
+			Line 0 "Error retrieving DHCP Options"
+		}
+		ElseIf($HTML)
+		{
+			WriteHTMLLine 0 0 "Error retrieving DHCP Options"
+		}
+	}
+	Else
+	{
+		If($MSWord -or $PDF)
+		{
+			WriteWordLine 0 1 "There were no DHCP Options"
+		}
+		ElseIf($Text)
+		{
+			Line 0 "There were no DHCP Options"
+		}
+		ElseIf($HTML)
+		{
+			WriteHTMLLine 0 1 "There were no DHCP Options"
+		}
+	}
+}
+
 Function ProcessHardware
 {
 	#V1.40 added
@@ -11501,6 +12074,7 @@ Function ProcessScriptEnd
 		Out-File -FilePath $SIFile -Append -InputObject "From               : $($From)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "HW Inventory       : $($Hardware)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "Include Leases     : $($IncludeLeases)" 4>$Null
+		Out-File -FilePath $SIFile -Append -InputObject "Include Options    : $($IncludeOptions)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "Log                : $($Log)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "Save As HTML       : $($HTML)" 4>$Null
 		Out-File -FilePath $SIFile -Append -InputObject "Save As PDF        : $($PDF)" 4>$Null
@@ -11607,6 +12181,11 @@ ForEach($DHCPServer in $Script:DHCPServerNames)
 	ProcessIPv4Filters
 
 	ProcessIPv6Properties
+	
+	If($IncludeOptions)
+	{
+		ProcessDHCPOptions
+	}
 
 	ProcessHardware
 }


### PR DESCRIPTION
#Version 1.43 17-Apr-2020
#	Add parameter IncludeOptions to add DHCP Options to report.
#		New Function ProcessDHCPOptions
#		Update Functions ShowScriptOptions and ProcessScriptEnd 
#		Update Help Text
#	Cleanup spacing in some of the Write-Verbose statements
#	In the GetIPv4ScopeData functions, ignore Option ID 81
#		This Option ID is set when Name Protection is disabled in the DNS
#		tab in a Scope's Properties. Option ID 81 is not in the Predefined Options.
#		https://carlwebster.com/the-mysterious-microsoft-dhcp-option-id-81/
#	Reorder parameters
#	Update Function SendEmail to handle anonymous unauthenticated email
#		Update Help Text with examples
#	Update script to match updates to other documentation scripts
#		Checking for multiple output formats selected
#		Change Text output to use [System.Text.StringBuilder]
#		Function Line
#		Function SaveandCloseTextDocument
#		Function WriteWordLine
#		Function WriteHTMLLine
#		Function AddHTMLTable
#		Function FormatHTMLTable
#		Function FormatHTMLTable
#		Function CheckHTMLColor